### PR TITLE
feat: implement content post

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -52,5 +52,34 @@
             </symbol>
         </defs>
         <use href="#logo-sudene" />
+
+               <symbol viewBox="0 0 18 18" id="link-arrow">
+            <path
+                d="M9 3H3C2.46957 3 1.96086 3.21071 1.58579 3.58579C1.21071 3.96086 1 4.46957 1 5V15C1 15.5304 1.21071 16.0391 1.58579 16.4142C1.96086 16.7893 2.46957 17 3 17H13C13.5304 17 14.0391 16.7893 14.4142 16.4142C14.7893 16.0391 15 15.5304 15 15V9"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                fill="none"
+            />
+            <path
+                d="M8 10L17 1"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                fill="none"
+            />
+            <path
+                d="M12 1H17V6"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                fill="none"
+            />
+        </symbol>
+
+
     </defs>
 </svg>

--- a/src/components/ContentPost/ContentPost.styles.tsx
+++ b/src/components/ContentPost/ContentPost.styles.tsx
@@ -1,0 +1,59 @@
+"use client";
+import styled from "styled-components";
+import Image from "next/image";
+import { Icon } from "../Icon/Icon";
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 19rem;
+  max-height: 22rem;
+  width: 100%;
+`;
+
+export const DateWrapper = styled.div`
+  min-height: 1.5rem;
+  text-align: right;
+  font-size: 0.8rem;
+`;
+
+export const TitleWrapper = styled.summary`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-top: 0.5rem;
+  gap: 1rem;
+  justify-content: space-between;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.6;
+    transition: 200ms;
+  }
+`;
+
+export const Title = styled.h3`
+  font-weight: bold;
+  text-align: left;
+`;
+
+export const ArrowIcon = styled(Icon)`
+  flex-shrink: 0;
+`;
+
+export const Link = styled.a`
+  text-decoration: none;
+`;
+
+export const Thumb = styled(Image)`
+  object-fit: cover;
+  object-position: top;
+  transition: 300ms;
+  border-radius: 0.5rem;
+  box-shadow: 0.5rem 0.5rem 1rem #cbcaca;
+  border: 0.1rem solid #cbcaca;
+
+  &:hover {
+    transform: scale(1.02);
+  }
+`;

--- a/src/components/ContentPost/ContentPost.tsx
+++ b/src/components/ContentPost/ContentPost.tsx
@@ -1,0 +1,37 @@
+import { IPublication } from "@/utils/interfaces";
+import {
+  ContentWrapper,
+  Link,
+  Thumb,
+  Title,
+  TitleWrapper,
+  ArrowIcon,
+  DateWrapper,
+} from "./ContentPost.styles";
+
+const ContentPost = ({ content }: { content: { fields: IPublication } }) => {
+  const { title, thumb, link, date } = content.fields;
+  const dateObj = date ? new Date(date) : null;
+  const formattedDate = dateObj ? dateObj.toLocaleDateString("pt-BR") : "";
+
+  return (
+    <ContentWrapper>
+      <DateWrapper>{formattedDate}</DateWrapper>
+      <Link target="_blank" href={link}>
+        <Thumb
+          src={`https:${thumb.fields.file.url}`}
+          alt=""
+          width={310}
+          height={260}
+        />
+
+        <TitleWrapper>
+          <Title>{title}</Title>
+          <ArrowIcon id={"link-arrow"} size={16} />
+        </TitleWrapper>
+      </Link>
+    </ContentWrapper>
+  );
+};
+
+export default ContentPost;

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -43,3 +43,17 @@ export interface ISectionHeader {
     subtitle?: string;
   };
 }
+
+export interface IPublication {
+  title: string;
+  link: string;
+  thumb: {
+    fields: {
+      file: {
+        url: string;
+      };
+    };
+  };
+  type: string;
+  date?: Date;
+}


### PR DESCRIPTION
This PR implements this content post, which can be a newsletter, a data panel, or additional content

![image](https://github.com/user-attachments/assets/444d6eda-1fbf-4527-b8fb-3044236cf909)

### How to test it
Add this code to page.tsx.

- imports
  ```tsx
  import ContentPost from "@/components/ContentPost/ContentPost";
  import { IPublication } from "@/utils/interfaces";
  
 - getContent 
 ```tsx
 const { partners, sectionHead, post } = await getContent([
  "partners",
  "sectionHead",
  "post",
]);
```

- ContentPost inside HubTemplate
```tsx
  {post?.map((post: { fields: IPublication }) => (
    <ContentPost content={post} />
  ))}

