### PR TITLE
refact: buttons

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "@glidejs/glide": "^3.7.1",
         "@google/earthengine": "^0.1.402",
         "@next/third-parties": "^14.2.3",
+        "@radix-ui/react-slot": "^1.2.0",
         "@types/google-earth": "^0.0.8",
         "@types/next": "^8.0.7",
         "braces": ">=3.0.3",
+        "class-variance-authority": "^0.7.1",
         "contentful": "^10.11.10",
         "contentful-management": "^11.48.0",
         "express": "^4.19.2",
@@ -28,7 +30,8 @@
         "react-dom": "^18",
         "sass": "^1.77.8",
         "styled-components": "^6.1.8",
-        "swiper": "^11.1.14"
+        "swiper": "^11.1.14",
+        "tailwind-merge": "^3.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.1.1",
@@ -858,6 +861,37 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
+      "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.36.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.36.0.tgz",
@@ -1156,7 +1190,6 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.4.tgz",
       "integrity": "sha512-bjV6sqycCEa+AQSt2Kr7wpGF1bOZJ5wsqnLEkqSbM/JEHxx/yhMH8wHmdkPyApF9xhHeMSwnnkDUUMMM/hYnXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.1.4",
@@ -2515,6 +2548,17 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -2600,6 +2644,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -7941,6 +7993,15 @@
       ],
       "engines": {
         "node": ">= 4.7.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
+      "integrity": "sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "@glidejs/glide": "^3.7.1",
     "@google/earthengine": "^0.1.402",
     "@next/third-parties": "^14.2.3",
+    "@radix-ui/react-slot": "^1.2.0",
     "@types/google-earth": "^0.0.8",
     "@types/next": "^8.0.7",
     "braces": ">=3.0.3",
+    "class-variance-authority": "^0.7.1",
     "contentful": "^10.11.10",
     "contentful-management": "^11.48.0",
     "express": "^4.19.2",
@@ -37,7 +39,8 @@
     "react-dom": "^18",
     "sass": "^1.77.8",
     "styled-components": "^6.1.8",
-    "swiper": "^11.1.14"
+    "swiper": "^11.1.14",
+    "tailwind-merge": "^3.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.1.1",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:is(.dark *));
+
 @theme {
   --color-green-neutro: #D6E9DB;
   --color-green-100: #EEFFF3;
@@ -101,4 +103,120 @@
   --color-grey-900: #484445;
   --color-grey-1000: #3E3C3D;
   --color-grey-1100: #292829;
+}
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }

--- a/src/components/About/About.styles.tsx
+++ b/src/components/About/About.styles.tsx
@@ -1,6 +1,5 @@
 "use client";
 import styled from "styled-components";
-import Link from "next/link";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -50,21 +49,5 @@ export const Subtitle = styled.p`
 
   @media (max-width: 800px) {
     font-size: 0.9rem;
-  }
-`;
-
-export const Button = styled(Link)`
-  text-decoration: none;
-  border: 1px solid ${({ theme }) => theme.colors.green}80;
-  padding: 0.5rem 1.5rem;
-  color: ${({ theme }) => theme.colors.green};
-  border-radius: 4px;
-  transition: 300ms;
-  cursor: not-allowed;
-  font-size: 0.8rem;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.green}90;
-    color: white;
   }
 `;

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -1,10 +1,5 @@
-import {
-  Button,
-  ContentWrapper,
-  Subtitle,
-  Title,
-  Wrapper,
-} from "./About.styles";
+import { LinkButton } from "../LinkButton/LinkButton";
+import { ContentWrapper, Subtitle, Title, Wrapper } from "./About.styles";
 
 export const AboutSection = ({ header }: { header: { fields: any } }) => {
   const { id, title, subtitle } = header.fields;
@@ -14,7 +9,7 @@ export const AboutSection = ({ header }: { header: { fields: any } }) => {
       <ContentWrapper>
         <Title>{title}</Title>
         <Subtitle>{subtitle}</Subtitle>
-        <Button href="#">Saiba mais</Button>
+        <LinkButton href="/" text="Saiba mais" />
       </ContentWrapper>
     </Wrapper>
   );

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -9,7 +9,7 @@ export const AboutSection = ({ header }: { header: { fields: any } }) => {
       <ContentWrapper>
         <Title>{title}</Title>
         <Subtitle>{subtitle}</Subtitle>
-        <LinkButton href="/" text="Saiba mais" />
+        <LinkButton href="/">Saiba mais</LinkButton>
       </ContentWrapper>
     </Wrapper>
   );

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -1,15 +1,15 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Icon } from "../Icon/Icon";
+import { ReactNode } from "react";
 
 export const LinkButton = ({
   href,
-  text,
+  children,
   variant = "primary",
   className = "",
 }: {
   href: string;
-  text: string;
+  children: ReactNode;
   variant?: "primary" | "secondary";
   className?: string;
 }) => {
@@ -19,15 +19,7 @@ export const LinkButton = ({
       variant={variant}
       className={`w-full md:w-auto ${className}`}
     >
-      <Link href={href}>
-        {text}
-        {variant === "secondary" && (
-          <Icon
-            id="expand"
-            className="transform -rotate-90 !w-[8px] !h-[8px]"
-          />
-        )}
-      </Link>
+      <Link href={href}>{children}</Link>
     </Button>
   );
 };

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { Icon } from "../Icon/Icon";
+
+export const LinkButton = ({
+  href,
+  text,
+  variant = "primary",
+  className = "",
+}: {
+  href: string;
+  text: string;
+  variant?: "primary" | "secondary";
+  className?: string;
+}) => {
+  return (
+    <Button
+      asChild
+      variant={variant}
+      className={`w-full md:w-auto ${className}`}
+    >
+      <Link href={href}>
+        {text}
+        {variant === "secondary" && (
+          <Icon
+            id="expand"
+            className="transform -rotate-90 !w-[8px] !h-[8px]"
+          />
+        )}
+      </Link>
+    </Button>
+  );
+};

--- a/src/components/ProjectCard/ProjectCard.styles.tsx
+++ b/src/components/ProjectCard/ProjectCard.styles.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import styled from "styled-components";
-import { Icon } from "../Icon/Icon";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -74,31 +73,4 @@ export const Description = styled.p`
   transition: 300ms;
   line-height: 1.2rem;
   color: #555;
-`;
-
-export const ArrowIcon = styled(Icon)`
-  flex-shrink: 0;
-  height: 1.3rem;
-`;
-
-export const Button = styled.button`
-  text-decoration: none;
-  border: 1px solid ${({ theme }) => theme.colors.green}80;
-  color: ${({ theme }) => theme.colors.green};
-  border-radius: 4px;
-  transition: 300ms;
-  cursor: pointer;
-  font-size: 0.8rem;
-  width: 100%;
-  padding: 0.2rem 0rem;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.3rem;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.green}90;
-    color: white;
-  }
 `;

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -6,11 +6,10 @@ import {
   TextWrapper,
   Title,
   Description,
-  Button,
-  ArrowIcon,
   Link,
   ThumbContainer,
 } from "./ProjectCard.styles";
+import { LinkButton } from "../LinkButton/LinkButton";
 
 const ProjectCard = ({ project }: { project: { fields: Project } }) => {
   const { name, description, link, thumb } = project.fields;
@@ -32,10 +31,7 @@ const ProjectCard = ({ project }: { project: { fields: Project } }) => {
           <Title>{name}</Title>
           <Description>{description}</Description>
         </TextWrapper>
-        <Button as="a" href={link} target="_blank">
-          <ArrowIcon id={"link-arrow"} size={12} />
-          Acessar
-        </Button>
+        <LinkButton href={link} text="Acessar" className="md:w-full" />
       </InfoWrapper>
     </Wrapper>
   );

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -31,7 +31,9 @@ const ProjectCard = ({ project }: { project: { fields: Project } }) => {
           <Title>{name}</Title>
           <Description>{description}</Description>
         </TextWrapper>
-        <LinkButton href={link} text="Acessar" className="md:w-full" />
+        <LinkButton href={link} className="md:w-full">
+          Acessar
+        </LinkButton>
       </InfoWrapper>
     </Wrapper>
   );

--- a/src/components/RecentSection/RecentSection.styles.tsx
+++ b/src/components/RecentSection/RecentSection.styles.tsx
@@ -56,16 +56,6 @@ export const Subtitle = styled.p`
   }
 `;
 
-export const Button = styled(Link)`
-  width: max-content;
-  white-space: nowrap;
-  transition: 300ms;
-
-  &:hover {
-    opacity: 0.6;
-  }
-`;
-
 export const ContentWrapper = styled.div`
   width: 100%;
   max-width: 1440px;

--- a/src/components/RecentSection/RecentSection.tsx
+++ b/src/components/RecentSection/RecentSection.tsx
@@ -1,7 +1,6 @@
 import { IPublication } from "@/utils/interfaces";
 import Carousel from "../Carousel/Carousel";
 import {
-  Button,
   Card,
   ContentWrapper,
   HeaderWrapper,
@@ -12,6 +11,7 @@ import {
 } from "./RecentSection.styles";
 import { Header } from "./RecentSection.styles";
 import ContentPost from "../ContentPost/ContentPost";
+import { LinkButton } from "../LinkButton/LinkButton";
 
 export const RecentSection = ({
   header,
@@ -50,7 +50,9 @@ export const RecentSection = ({
           <Title href="/posts">
             {title} <RightIcon id="expand" size={14} />
           </Title>
-          <Button href="/posts">Ver todos</Button>
+          <div className="hidden md:block">
+            <LinkButton href="/posts" text="Ver Todos" variant="secondary" />
+          </div>
         </Header>
         <Subtitle>{subtitle}</Subtitle>
       </HeaderWrapper>
@@ -68,6 +70,9 @@ export const RecentSection = ({
               </Card>
             ))}
         </Carousel>
+        <div className="block md:hidden mt-6 flex justify-center w-full">
+          <LinkButton href="/posts" text="Ver Todos" variant="secondary" />
+        </div>
       </ContentWrapper>
     </Wrapper>
   );

--- a/src/components/RecentSection/RecentSection.tsx
+++ b/src/components/RecentSection/RecentSection.tsx
@@ -12,6 +12,7 @@ import {
 import { Header } from "./RecentSection.styles";
 import ContentPost from "../ContentPost/ContentPost";
 import { LinkButton } from "../LinkButton/LinkButton";
+import { Icon } from "../Icon/Icon";
 
 export const RecentSection = ({
   header,
@@ -51,7 +52,13 @@ export const RecentSection = ({
             {title} <RightIcon id="expand" size={14} />
           </Title>
           <div className="hidden md:block">
-            <LinkButton href="/posts" text="Ver Todos" variant="secondary" />
+            <LinkButton href="/posts" variant="secondary">
+              Ver Todos
+              <Icon
+                id="expand"
+                className="transform -rotate-90 !w-[8px] !h-[8px]"
+              />
+            </LinkButton>
           </div>
         </Header>
         <Subtitle>{subtitle}</Subtitle>
@@ -71,7 +78,13 @@ export const RecentSection = ({
             ))}
         </Carousel>
         <div className="block md:hidden mt-6 flex justify-center w-full">
-          <LinkButton href="/posts" text="Ver Todos" variant="secondary" />
+          <LinkButton href="/posts" variant="secondary">
+            Ver Todos
+            <Icon
+              id="expand"
+              className="transform -rotate-90 !w-[8px] !h-[8px]"
+            />
+          </LinkButton>
         </div>
       </ContentWrapper>
     </Wrapper>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        primary:
+          "bg-[var(--color-green-800)] text-white hover:bg-[var(--color-green-900)] rounded-md py-2 px-4 gap-[10px] min-w-[105px] min-h-[40px] font-sans text-sm leading-6",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-white text-[var(--color-green-900)] border border-[var(--color-grey-200)] hover:bg-[var(--color-grey-100)] rounded-md py-2 px-4 gap-[10px] w-[126px] min-h-[40px] font-sans text-sm leading-6",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,19 +10,19 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          "bg-[var(--color-green-800)] text-white hover:bg-[var(--color-green-900)] rounded-md py-2 px-4 gap-[10px] min-w-[105px] min-h-[40px] font-sans text-sm leading-6",
+          "bg-green-800 text-white hover:bg-green-900 min-w-[105px] font-sans text-sm leading-6",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
-          "bg-white text-[var(--color-green-900)] border border-[var(--color-grey-200)] hover:bg-[var(--color-grey-100)] rounded-md py-2 px-4 gap-[10px] w-[126px] min-h-[40px] font-sans text-sm leading-6",
+          "bg-white text-green-900 border border-grey-200 hover:bg-grey-100 w-[126px] font-sans text-sm leading-6",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: "h-10 rounded-md px-4 py-2 gap-[10px] has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
This PR refactors the button components across the home page to align them with the new design and integrate the Shadcn library. Two variations have been implemented: **Primary and Secondary buttons**. These buttons have already been applied to some sections of the site (recent section, about section and "projects" section)

Primary button: 
![image](https://github.com/user-attachments/assets/6a3dc9b8-7519-412a-acc5-5ea00c536c14)
![image](https://github.com/user-attachments/assets/84e5ae91-36cf-4c5e-8247-83a4d2fa741b)

Secondary button:
![image](https://github.com/user-attachments/assets/f01a8bff-9a21-473e-a5d8-a92960eaf31e)
