### PR TITLE
feat: implement page header component

### DIFF
--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,17 @@
+import { IPageHeader } from "@/utils/interfaces";
+
+const PageHeader = ({ content }: { content: { fields: IPageHeader } }) => {
+  const { title, subtitle } = content.fields;
+
+  return (
+    <section className="flex items-center justify-center bg-grey-100 w-full min-h-[200px] px-6 pt-9 lg:px-20 lg:pt-12 pb-9">
+      <div className="flex flex-col items-left gap-6 max-w-[1440px]">
+        <h1 className="font-extrabold text-[30px] lg:text-4xl">{title}</h1>
+
+        <h2 className="font-medium">{subtitle}</h2>
+      </div>
+    </section>
+  );
+};
+
+export default PageHeader;

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -6,9 +6,9 @@ const PageHeader = ({ content }: { content: { fields: IPageHeader } }) => {
   return (
     <section className="flex items-center justify-center bg-grey-100 w-full min-h-[200px] px-6 pt-9 lg:px-20 lg:pt-12 pb-9">
       <div className="flex flex-col items-left gap-6 max-w-[1440px]">
-        <h1 className="font-extrabold text-[30px] lg:text-4xl">{title}</h1>
+        <h1 className="font-extrabold text-[30px] lg:text-[48px]">{title}</h1>
 
-        <h2 className="font-medium">{subtitle}</h2>
+        <h2 className="text-[16px]">{subtitle}</h2>
       </div>
     </section>
   );

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -132,3 +132,8 @@ export interface IMainBanner {
     };
   };
 }
+
+export interface IPageHeader {
+  title: string;
+  subtitle: string;
+}


### PR DESCRIPTION
This PR adds the PageHeader component, which displays the page's title and description, as shown below:

![image](https://github.com/user-attachments/assets/e2783409-cf00-4c48-9c0c-2fbe016a3ed7)

## How to test it

import the component in `page.tsx`:

```
import PageHeader from "@/components/PageHeader/PageHeader";
```

now add this:

```
  const {
    partners,
    sectionHead,
    post: posts,
    previewCards,
    theme,
    mainBanner,
    pageHeaders
  } = await getContent([
    "partners",
    "sectionHead",
    "post",
    "previewCards",
    "panels",
    "theme",
    "mainBanner",
    "pageHeaders",
  ]);
```

and finally, render the component using a specific ID

```
<PageHeader content={pageHeaders.find(
          (section: { fields: { id: string } }) => section.fields.id === "projects",
        )} />
```

You can test with the following IDs: "projects", "about", "posts", and "panels".