### PR TITLE
Fix: Prevents filter from overflowing the screen

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,7 +14,7 @@ import { macroThemes } from "@/utils/constants";
 
 const Header = ({ content }: { content: { fields: ISection }[] }) => {
   return (
-    <div className="flex items-center justify-between px-[80px] py-[18px] border-b-2 shadow-sm bg-white">
+    <div className="flex items-center justify-between px-[80px] py-[18px] border-b-2 shadow-sm bg-white z-10">
       <Link href="/" className="flex items-center gap-2">
         <Icon id="logo-DNE" width={99} height={47} />
       </Link>

--- a/src/components/PostsGrid/FilterForm.tsx
+++ b/src/components/PostsGrid/FilterForm.tsx
@@ -67,7 +67,7 @@ export function FilterForm({
           collisionPadding={{
             top: 5000,
           }} /* Huge number so the popover never pops on top */
-          className="flex flex-col gap-6 w-auto p-6 box-pointer-events-auto overflow-auto max-h-scree z-10"
+          className="flex flex-col gap-6 w-auto p-6 box-pointer-events-auto overflow-auto max-h-screen z-0"
           align="start"
         >
           <h3 className="text-xl font-semibold">Filtros</h3>

--- a/src/components/PostsGrid/FilterForm.tsx
+++ b/src/components/PostsGrid/FilterForm.tsx
@@ -64,7 +64,10 @@ export function FilterForm({
           </PopoverTrigger>
         </Button>
         <PopoverContent
-          className="flex flex-col gap-6 w-auto p-6 box-pointer-events-auto overflow-auto max-h-screen z-0"
+          collisionPadding={{
+            top: 5000,
+          }} /* Huge number so the popover never pops on top */
+          className="flex flex-col gap-6 w-auto p-6 box-pointer-events-auto overflow-auto max-h-scree z-10"
           align="start"
         >
           <h3 className="text-xl font-semibold">Filtros</h3>


### PR DESCRIPTION
## Description

This PR prevents the filter modal from overflowing the screens and also prevents the header from overlapping the filter

## How to test it

Just check if the filter popover component appears properly on different screen sizes