### PR TITLE
Refact: Update missao visao e valores to compromisso

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -31,7 +31,7 @@ export default async function AboutPage() {
     contato: <ContactSection content={contactInfo} />,
     "rede-colaboracao": <PartnersSection content={partnersInfo[0]} />,
     "nossa-historia": <HistorySection content={about[0]} />,
-    "missao-visao-valor": <ValuesSection content={visionMissionValues} />,
+    compromisso: <ValuesSection content={visionMissionValues} />,
   };
 
   return (

--- a/src/components/AboutContent/AboutContent.tsx
+++ b/src/components/AboutContent/AboutContent.tsx
@@ -25,7 +25,7 @@ export const AboutContent = ({
 
   const orderedContent = sortContentByDesiredOrder<ITab>(tabsHeader, [
     "history",
-    "mission",
+    "compromisso",
     "partners",
     "contact",
   ]);

--- a/src/components/ValuesSection/ValuesSection.tsx
+++ b/src/components/ValuesSection/ValuesSection.tsx
@@ -1,51 +1,25 @@
 import { IValues } from "@/utils/interfaces";
-import { Icon } from "../Icon/Icon";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
-import { sortContentByDesiredOrder } from "@/utils/functions";
+import Image from "next/image";
 
 const ValuesSection = ({ content }: { content: { fields: IValues }[] }) => {
-  const orderedContent = sortContentByDesiredOrder<IValues>(content, [
-    "mission",
-    "vision",
-    "values",
-  ]);
+  const { title, thumb, details } = content[0].fields;
 
   return (
     <section className="flex items-center flex-col w-full px-6 py-9 lg:px-[80px] lg:py-[32px]">
       <div className="flex flex-col w-full lg:max-w-[1440px] h-fit gap-[24px]">
-        <h1 className="text-[24px] lg:text-[30px] font-bold">
-          Missão, Visão e Valor
-        </h1>
-
-        <div className="flex flex-col items-center gap-[24px] ">
-          {orderedContent.map(({ fields: { title, details, id } }, index) => (
-            <div
-              key={index}
-              className="flex flex-col lg:flex-row items-stretch w-full h-fit rounded-lg overflow-hidden border border-[#EFEFEF] shadow-sm"
-            >
-              <div className="flex items-center px-[24px] py-[24px] bg-green-900 gap-[10px] lg:items-center lg:justify-center w-full lg:w-[162px] lg:min-h-[198px] lg:gap-4">
-                <div className="block lg:hidden">
-                  <Icon id={id} size={64} />
-                </div>
-
-                <div className="hidden lg:block">
-                  <Icon id={id} size={114} />
-                </div>
-                <h2 className="text-[32px] text-white font-bold lg:hidden">
-                  {title}
-                </h2>
-              </div>
-
-              <div className="flex flex-col justify-center w-full gap-[6px] p-[24px]">
-                <h2 className="text-[20px] font-bold hidden lg:block">
-                  {title}
-                </h2>
-                <div className="text-grey-800 [&_ul]:list-disc [&_ul]:list-outside [&_ul]:pl-5 [&_li]:m-1">
-                  {documentToReactComponents(details)}
-                </div>
-              </div>
-            </div>
-          ))}
+        <h1 className="text-[24px] lg:text-[30px] font-bold">{title}</h1>
+        <div className="">
+          <Image
+            className="w-full float-none md:float-left h-full md:max-w-[300px] object-cover rounded-md aspect-[16/9] order-1 mb-4 mr-4"
+            src={`https:${thumb.fields.file.url}`}
+            alt={"Sobre nós"}
+            width={1200}
+            height={800}
+          />
+          <div className="h-full text-gray-800 order-2 text-justify">
+            {documentToReactComponents(details)}
+          </div>
         </div>
       </div>
     </section>

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -164,6 +164,13 @@ export interface IPartners {
 }
 export interface IValues {
   title: string;
+  thumb: {
+    fields: {
+      file: {
+        url: string;
+      };
+    };
+  };
   details: any;
   id: string;
 }


### PR DESCRIPTION
## Description

This PR update the previous "MIssão, visão & valores" section to a new layout

![image](https://github.com/user-attachments/assets/473b8241-c915-4790-a182-36ee3e25d162)


## How to test it

You'll just need to access the `/about?tab=compromisso` page and check if it's displayed correctly