### PR TITLE
chore: reorder sections about and data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,17 +44,17 @@ export default async function Home() {
           (section: { fields: { id: string } }) => section.fields.id === "new",
         )}
       />
-      <AboutSection
-        header={sectionHead.find(
-          (section: { fields: { id: string } }) =>
-            section.fields.id === "about",
-        )}
-      />
       <DataSection
         header={sectionHead.find(
           (sec: { fields: SectionHeader }) => sec.fields.id == "panels",
         )}
         categories={theme}
+      />
+      <AboutSection
+        header={sectionHead.find(
+          (section: { fields: { id: string } }) =>
+            section.fields.id === "about",
+        )}
       />
       <ProjectSection
         header={sectionHead.find(

--- a/src/components/AboutSection/AboutSection.tsx
+++ b/src/components/AboutSection/AboutSection.tsx
@@ -5,7 +5,7 @@ export const AboutSection = ({ header }: { header: { fields: any } }) => {
   const { id, title, subtitle, thumb } = header.fields;
 
   return (
-    <section id={id} className="w-full bg-grey-100 py-8 lg:py-12">
+    <section id={id} className="w-full py-8 lg:py-12">
       <div className="w-full max-w-[1440px] mx-auto px-4 flex flex-col gap-6">
         <h2 className="text-[30px] leading-[36px] tracking-[-0.0075em] font-bold text-left">
           {title}

--- a/src/components/CategoryCard/CategoryCard.tsx
+++ b/src/components/CategoryCard/CategoryCard.tsx
@@ -11,7 +11,7 @@ const CategoryCard = ({
   return (
     <Link
       href={`/explore?category=${category.sys.id}&page=1`}
-      className="flex justify-between items-center rounded-sm shadow-sm p-4 w-full bg-grey-100 hover:bg-grey-200 border border-grey-200 hover:border-grey-300 cursor-pointer transition duration-300"
+      className="flex justify-between items-center rounded-sm shadow-sm p-4 w-full bg-white hover:bg-grey-200 border border-grey-200 hover:border-grey-300 cursor-pointer transition duration-300"
       key={category.fields.id}
     >
       <div className="flex flex-col md:flex-row w-full md:w-fit items-center justify-center gap-4">

--- a/src/components/DataSection/DataSection.tsx
+++ b/src/components/DataSection/DataSection.tsx
@@ -27,39 +27,38 @@ const DataSection = ({
   });
 
   return (
-    <section
-      className="w-full max-w-[1440px] px-4 py-10 my-0 lg:my-8 content-center flex flex-col gap-6 box-border"
-      id={title}
-    >
-      <div className="flex flex-col gap-3">
-        <div className="flex justify-between w-full">
-          <h2 className="text-3xl font-semibold">{title}</h2>
-          <LinkButton
-            href="/explore"
-            variant="secondary"
-            className="w-fit hidden md:flex"
-          >
-            <p>Ver Todos</p>
-            <Icon className="rotate-270 size-2" id="expand" />
-          </LinkButton>
+    <section className="bg-grey-100 w-full" id={title}>
+      <div className="max-w-[1440px] px-4 py-10 mx-auto my-0 lg:my-8 content-center flex flex-col gap-6 box-border">
+        <div className="flex flex-col gap-3">
+          <div className="flex justify-between w-full">
+            <h2 className="text-3xl font-semibold">{title}</h2>
+            <LinkButton
+              href="/explore"
+              variant="secondary"
+              className="w-fit hidden md:flex"
+            >
+              <p>Ver Todos</p>
+              <Icon className="rotate-270 size-2" id="expand" />
+            </LinkButton>
+          </div>
+          <p className="text-sm">{subtitle}</p>
         </div>
-        <p className="text-sm">{subtitle}</p>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          {filteredData?.map(
+            (category: { fields: MacroTheme; sys: { id: string } }) => (
+              <CategoryCard key={category.fields.id} category={category} />
+            ),
+          )}
+        </div>
+        <LinkButton
+          href="/explore?page=1"
+          variant="secondary"
+          className="md:hidden"
+        >
+          <p>Ver Todos</p>
+          <Icon className="rotate-270 size-2" id="expand" />
+        </LinkButton>
       </div>
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-        {filteredData?.map(
-          (category: { fields: MacroTheme; sys: { id: string } }) => (
-            <CategoryCard key={category.fields.id} category={category} />
-          ),
-        )}
-      </div>
-      <LinkButton
-        href="/explore?page=1"
-        variant="secondary"
-        className="md:hidden"
-      >
-        <p>Ver Todos</p>
-        <Icon className="rotate-270 size-2" id="expand" />
-      </LinkButton>
     </section>
   );
 };

--- a/src/components/DataSection/DataSection.tsx
+++ b/src/components/DataSection/DataSection.tsx
@@ -35,7 +35,7 @@ const DataSection = ({
             <LinkButton
               href="/explore"
               variant="secondary"
-              className="w-fit hidden md:flex"
+              className="w-fit bg-grey-100 border-grey-300 hidden md:flex"
             >
               <p>Ver Todos</p>
               <Icon className="rotate-270 size-2" id="expand" />
@@ -53,7 +53,7 @@ const DataSection = ({
         <LinkButton
           href="/explore?page=1"
           variant="secondary"
-          className="md:hidden"
+          className="md:hidden bg-grey-100 border-grey-300"
         >
           <p>Ver Todos</p>
           <Icon className="rotate-270 size-2" id="expand" />

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -17,20 +17,17 @@ export const LinkButton = ({
   disabled?: boolean;
 }) => {
   return (
-    <div
+    <Button
+      asChild
+      variant={disabled ? "ghost" : variant}
+      disabled={disabled}
       className={cn(
-        `w-full md:w-auto  ${disabled && "cursor-not-allowed"}`,
+        "w-full md:w-auto",
+        disabled && "cursor-not-allowed pointer-events-none",
         className,
       )}
     >
-      <Button
-        asChild
-        variant={disabled ? "ghost" : variant}
-        disabled={disabled}
-        className={`w-full ${disabled && "pointer-events-none"}`}
-      >
-        <Link href={href}>{children}</Link>
-      </Button>
-    </div>
+      <Link href={href}>{children}</Link>
+    </Button>
   );
 };


### PR DESCRIPTION
This PR changes the order of the About and Data sections in the homepage layout, data section now comes first, just like this: 

![image](https://github.com/user-attachments/assets/716bf406-2190-4de6-8278-161e478a08d9)
