### PR TITLE
Update about tabs details

### DIFF
--- a/src/components/AboutBigCard/AboutBigCard.tsx
+++ b/src/components/AboutBigCard/AboutBigCard.tsx
@@ -5,18 +5,22 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 const AboutBigCard = ({ content }: { content: IAbout }) => {
   const { details, thumb, id } = content;
 
+  console.log(thumb);
+
   return (
     <section className="flex items-center justify-center w-full">
       <div className="flex flex-col items-left">
         <h2 className="font-semibold text-3xl">{id}</h2>
         <div className=" my-5">
-          <Image
-            className="w-full float-none md:float-left h-full md:max-w-[450px] object-cover rounded-md aspect-[4/3] order-1 mb-4 mr-4"
-            src={`${thumb.url}`}
-            alt={"Sobre nós"}
-            width={600}
-            height={600}
-          />
+          {thumb && (
+            <Image
+              className="w-full float-none md:float-left h-full md:max-w-[450px] object-cover rounded-md aspect-[4/3] order-1 mb-4 mr-4"
+              src={thumb?.url || ""}
+              alt={"Sobre nós"}
+              width={600}
+              height={600}
+            />
+          )}
           <div className="h-full text-gray-800 order-2 text-justify">
             {documentToReactComponents(details.json)}
           </div>

--- a/src/components/AboutSection/AboutSection.tsx
+++ b/src/components/AboutSection/AboutSection.tsx
@@ -18,7 +18,7 @@ export const AboutSection = ({ header }: { header?: SectionHeader }) => {
         <div className="flex flex-col lg:flex-row gap-6">
           <Image
             alt=""
-            src={`${thumb?.url}`}
+            src={thumb?.url || ""}
             width={462}
             height={374}
             className="w-full lg:h-[374px] lg:w-[462px] rounded-lg"

--- a/src/components/ContentPost/ContentPost.tsx
+++ b/src/components/ContentPost/ContentPost.tsx
@@ -19,7 +19,7 @@ const ContentPost = ({ content }: { content: IPublication }) => {
           width={300}
           height={300}
           alt=""
-          src={`${thumb.url}`}
+          src={thumb?.url || ""}
           className="w-full aspect-7/4 block object-cover object-top transition-transform group-hover:scale-102 duration-300"
         />
       </div>

--- a/src/components/GalleryCarousel/GalleryCarousel.tsx
+++ b/src/components/GalleryCarousel/GalleryCarousel.tsx
@@ -50,7 +50,7 @@ const GalleryCarousel = ({
               return (
                 <CarouselItem
                   key={index}
-                  className={`flex justify-center items-center ${length}`}
+                  className={`pl-0 md:pl-4 flex justify-center items-center ${length}`}
                 >
                   {path ? (
                     <Link href={path}>

--- a/src/components/ProjectBigtCard/ProjectBigCard.tsx
+++ b/src/components/ProjectBigtCard/ProjectBigCard.tsx
@@ -24,7 +24,7 @@ const ProjectBigCard = ({
           >
             <Image
               className="w-full h-full object-cover rounded-md aspect-[16/9] mb-4"
-              src={`${thumb.url}`}
+              src={thumb?.url || ""}
               alt={name}
               width={800}
               height={800}

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -10,7 +10,7 @@ const ProjectCard = ({ project }: { project: Project }) => {
       <a href={link} className="w-full h-full">
         <Image
           className="w-full h-full object-cover rounded-t-md md:rounded-l-md md:rounded-tr-none"
-          src={`${thumb.url}`}
+          src={thumb?.url || ""}
           alt=""
           width={800}
           height={800}


### PR DESCRIPTION
# Description

This PR updates some details on the about page tabs:

1. Adds spacing to the gallery component;
2. Remove image from "nossa-historia" tab if the image isn't available;


## How to test it

You'll just need to check if the changes above are all really implemented and okay