### PR TITLE
fix: fix /explore and /posts alignment

### DIFF
--- a/src/components/Posts/Posts.tsx
+++ b/src/components/Posts/Posts.tsx
@@ -123,8 +123,8 @@ export const Posts = ({
   }, [filter, rootFilter, sorting]);
 
   return (
-    <section className="flex flex-col items-center gap-4 box-border w-full max-w-[1440px] px-6 py-16 lg:px-20 border-box">
-      <div className="flex flex-col lg:flex-row justify-between lg:items-center w-full gap-4">
+    <section className="flex flex-col items-center gap-4 box-border w-full px-6 py-16 lg:px-20">
+      <div className="flex flex-col lg:flex-row justify-between lg:items-center w-full gap-4 max-w-[1440px]">
         <h1 className="text-3xl font-semibold w-full">{header.title}</h1>
         <div className="flex flex-col lg:flex-row items-center gap-4 w-full">
           <FilterForm


### PR DESCRIPTION
## Description
This PR fixes the misalignment on the /explore and /posts pages

from this: 
<img width="1780" height="706" alt="image" src="https://github.com/user-attachments/assets/a17c16cc-8bbb-4fb2-bd29-6e3b843744a9" />

to this: 
<img width="1539" height="609" alt="image" src="https://github.com/user-attachments/assets/b4d01d33-f7c8-41da-9c10-ed65c14637be" />

## How to test it
1. Run the project
2. go to `/explore` or `/posts`
3. Check if it is properly aligned across **different screen sizes**