### PR TITLE
fix: fixes dashboards date misaligned

### DIFF
--- a/src/components/PowerBIContainer/PowerBiContainer.tsx
+++ b/src/components/PowerBIContainer/PowerBiContainer.tsx
@@ -14,7 +14,7 @@ const PowerBIContainer = ({
 
   return (
     <div className="flex flex-col w-full max-w-[1240px] h-full z-0 bg-white gap-2 overflow-x-scroll p-4">
-      <div className="flex flex-col sm:flex-row justify-between w-full py-4 sticky left-0">
+      <div className="flex flex-col sm:flex-row justify-between items-center w-full py-4 sticky left-0">
         <h2 className="text-left font-semibold text-3xl">{macroTheme}</h2>
         <span className="font-medium text-base mt-2 sm:mt-0">
           Publicado em: {formattedDate}


### PR DESCRIPTION
## Description
This PR fixes the dashboards misaligned date

From this: 
<img width="1776" height="627" alt="image" src="https://github.com/user-attachments/assets/1aecea73-2c69-4dad-8eb9-b8d63fba3485" />

To this: 
<img width="1282" height="124" alt="image" src="https://github.com/user-attachments/assets/087b657b-a567-4f23-983f-94b958d8933f" />

## How to test 
1. Run the project
2. go to any dashboard, for example you can try this one: http://localhost:3000/data-panel/analfabetismo
3. check if the date is aligned with the Title, if it's hard to notice, you can press F12 and use the console to hover over the div that’s covering the title and date