### PR TITLE
Limiting content of the connections page to 1440px horizontal

### DIFF
--- a/src/app/connections/page.tsx
+++ b/src/app/connections/page.tsx
@@ -22,13 +22,15 @@ export default async function Connections({}: {}) {
   return (
     <HubTemplate>
       <PageHeader content={pageHeaders.items[0]} />
-      {partners.items.map((partner: Project, index: number) => (
-        <ProjectBigCard
-          key={partner.name}
-          project={partner}
-          direction={index % 2 === 0 ? "left" : "right"}
-        />
-      ))}
+      <div className="w-full max-w-[1440px]">
+        {partners.items.map((partner: Project, index: number) => (
+          <ProjectBigCard
+            key={partner.name}
+            project={partner}
+            direction={index % 2 === 0 ? "left" : "right"}
+          />
+        ))}
+      </div>
     </HubTemplate>
   );
 }


### PR DESCRIPTION
## Description
This PR fixes the alignment of the "connections" page, limiting it to 1440px horizontal.


## How to test it
1. run the project
2. go to "/connections"
3. check alignment

##Note##
When testing this, note that the content is not aligned with the PageHeader or the Header. These components were fixed in another PR.