### PR TITLE
Fix: Macrothemes page alignment 

### DIFF
--- a/src/app/macrothemes/[slug]/page.tsx
+++ b/src/app/macrothemes/[slug]/page.tsx
@@ -67,8 +67,8 @@ export default async function MacroThemePage({
 
       {!!previewCardsCollection?.items?.length && (
         <section className="w-full bg-white">
-          <div className="w-full max-w-[1440px] mx-auto px-3 lg:px-20">
-            <div className="flex flex-col lg:px-6 pt-10 lg:pt-16 items-center [&>div:nth-child(2)]:mt-[28px]">
+          <div className="w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-20">
+            <div className="flex flex-col pt-10 lg:pt-16 items-center [&>div:nth-child(2)]:mt-[28px]">
               <PreviewContent
                 cards={previewCardsCollection.items}
                 header={sectionHeadCollection.items.find(


### PR DESCRIPTION
## Description ( Closed #165 )

This PR fixes the Macrothemes page alignment, and makes some minor UI and content adjustments.
### The “Indicadores em destaque” is properly aligned with the article title. 
<img width="719" height="404" alt="image" src="https://github.com/user-attachments/assets/5c578b16-e215-4a18-862a-623ad4bcdf34" />

### Switched section name
<img width="579" height="295" alt="image" src="https://github.com/user-attachments/assets/525087e1-cd41-4bcb-8dd9-77ac989a2496" />

## How to test it 

1. Run the app
2. Navigate to a macrotheme page (such as "Demografia")
3. Check the page

