### PR TITLE
refactor: show only three files on datacard

### DIFF
--- a/src/components/DataCard/DataCard.tsx
+++ b/src/components/DataCard/DataCard.tsx
@@ -208,7 +208,7 @@ export const DataCard = ({
           </h3>
           <div className="flex gap-2 items-center h-auto justify-between">
             <div className="hidden sm:flex flex-wrap self-end">
-              {files.map((file) => (
+              {files.slice(0, 3).map((file) => (
                 <button
                   key={file.name}
                   type="button"


### PR DESCRIPTION
## Description

This PR limits the maximum number of files displayed on each DataCard on the "Catálogo de Dados" page to 3.

<img width="1471" height="881" alt="image" src="https://github.com/user-attachments/assets/db9af6bc-952c-4e17-a5e3-5bd1784e75ba" />

<img width="856" height="54" alt="image" src="https://github.com/user-attachments/assets/b40d6e10-6473-43ab-aa78-17e7a97f9144" />

## How to test it

1. Run the application;
2. Go to the "Catálogo de Dados" page;
3. Check that the "Arquivos recentes" section displays at most 3 files.