### PR TITLE
Fix: fixes 'demografia' and 'meio ambiente' icons

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -68,11 +68,13 @@ export const POST_TYPES = {
 export const macroThemes: { [key: string]: string } = {
   economia_e_renda: "money",
   demografia: "user",
+  demografia_macro: "user",
   saude: "health",
   educacao: "book",
   infraestrutura_e_saneamento: "screwdriver",
   seguranca_hidrica: "drop",
   meio_ambiente: "leaf",
+  meio_ambiente_macro: "leaf",
   instrumentos_sudene: "instruments",
 };
 


### PR DESCRIPTION
## Description
Fixes icons not matching their macrothemes in the header navigation menu

<img width="237" height="285" alt="image" src="https://github.com/user-attachments/assets/eda89313-9679-44b9-914b-1617d4a825de" />

