### PR TITLE
refactor: rich text title 

### DIFF
--- a/src/components/MacroThemeBanner/MacroThemeBanner.tsx
+++ b/src/components/MacroThemeBanner/MacroThemeBanner.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { Icon } from "@/components/Icon/Icon";
 import { MacroTheme } from "@/utils/interfaces";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import { BLOCKS } from "@contentful/rich-text-types";
 import { cn } from "@/lib/utils";
 import { macroThemes } from "@/utils/constants";
 
@@ -16,10 +17,19 @@ export function MacroThemeBanner({
   className = "",
   priorityImage = true,
 }: Props) {
-  const title = content.name;
+  const name = content.name;
+  const title = content.title;
 
   const derivedTags = content.tags || [];
   const backgroundUrl = content.banner?.url ?? "";
+
+  const titleRenderOptions = {
+    renderNode: {
+      [BLOCKS.PARAGRAPH]: (_node: any, children: any) => (
+        <span className="block">{children}</span>
+      ),
+    },
+  };
 
   return (
     <section className={cn(`relative w-full`, className)}>
@@ -28,7 +38,7 @@ export function MacroThemeBanner({
           <Image
             className="absolute inset-0 w-full h-full object-cover object-[center_43%]"
             src={backgroundUrl}
-            alt={title}
+            alt={name}
             width={1920}
             height={1080}
             priority={priorityImage}
@@ -59,7 +69,10 @@ export function MacroThemeBanner({
                 <div className="flex flex-col gap-4 sm:gap-5 lg:gap-6 w-full max-w-[1044px]">
                   <div className="flex flex-col gap-2 md:text-left text-center">
                     <h1 className="text-white font-extrabold text-2xl sm:text-3xl md:text-4xl lg:text-[48px] leading-tight lg:leading-[48px] tracking-tight lg:tracking-[-0.012em]">
-                      {title}
+                      {documentToReactComponents(
+                        title.json,
+                        titleRenderOptions,
+                      )}
                     </h1>
 
                     {!!derivedTags?.length && (

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -83,6 +83,7 @@ export interface ReportData {
 
 export interface MacroTheme {
   name: string;
+  title: { json: any };
   id: string;
   color: string;
   sys: {

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -397,6 +397,9 @@ export const MACROTHEME_PAGE_QUERY = `
     themeCollection(limit: 1, where: { id: $slug }, preview: $preview) {
       items {
         name
+        title {
+          json
+        }
         id
         color
         tags


### PR DESCRIPTION
## Description (Closes #181 )

This PR refactors how the macrotheme banner title is rendered, improving support for multi-line content and ensuring proper rendering of rich text formatting from Contentful.

<img width="1033" height="277" alt="image" src="https://github.com/user-attachments/assets/ee7a713a-b962-4d45-84be-91477bdb3a75" />

## Changes

- Contentful: Added a new rich text field to the Tema content type to support structured title content
- Query & types: Updated the GraphQL query and TypeScript interface to fetch and type the new field
- Rendering: Replaced plain string rendering with documentToReactComponents to handle rich text nodes, enabling multi-line output and inline marks

## How to test

1. Run the application 
2. Open a Macro Theme page where the title has more than one line in Contentful
3. Confirm all lines of the title are displayed correctly in the banner
4. Confirm bold, italic, and other inline marks are still rendered correctly