### PR TITLE
Refactor/theme navigation order 

### DIFF
--- a/src/components/DataSection/DataSection.tsx
+++ b/src/components/DataSection/DataSection.tsx
@@ -2,6 +2,7 @@ import { MacroTheme, SectionHeader } from "@/utils/interfaces";
 import { Icon } from "@/components/Icon/Icon";
 import { LinkButton } from "@/components/LinkButton/LinkButton";
 import CategoryCard from "../CategoryCard/CategoryCard";
+import { THEMES_NAVIGATION_ORDER } from "@/utils/constants";
 
 const DataSection = ({
   header,
@@ -16,14 +17,13 @@ const DataSection = ({
   };
 
   const filteredData = categories?.sort((a, b) => {
-    if (a.sys.id < b.sys.id) {
-      return -1;
-    }
-    if (a.sys.id > b.sys.id) {
-      return 1;
-    }
+    const indexA = THEMES_NAVIGATION_ORDER.indexOf(a.id);
+    const indexB = THEMES_NAVIGATION_ORDER.indexOf(b.id);
 
-    return 0;
+    const posA = indexA === -1 ? 99 : indexA;
+    const posB = indexB === -1 ? 99 : indexB;
+
+    return posA - posB;
   });
 
   return (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -76,6 +76,17 @@ export const macroThemes: { [key: string]: string } = {
   instrumentos_sudene: "instruments",
 };
 
+export const THEMES_NAVIGATION_ORDER = [
+  "saude",
+  "educacao",
+  "economia_e_renda",
+  "demografia",
+  "infraestrutura_e_saneamento",
+  "meio_ambiente",
+  "seguranca_hidrica",
+  "instrumentos_sudene",
+];
+
 export const themes = {
   "Economia e Renda": "economia-e-renda",
   "Demografia": "demografia",


### PR DESCRIPTION
## Description

This PR refactors the way the DataSection sorts each theme, ensuring that 'Instrumentos de Ação da Sudene' is displayed last. #

<img width="1348" height="389" alt="image" src="https://github.com/user-attachments/assets/d10ce9fe-24ce-4067-a2ad-df0755357b75" />

## How to test it

On the home page, check if each card in section "Navegue por temas" is correctly ordered.