### PR TITLE
Refactor/different card icons

### DIFF
--- a/src/components/PreviewCard/PreviewCard.tsx
+++ b/src/components/PreviewCard/PreviewCard.tsx
@@ -5,9 +5,6 @@ import Link from "next/link";
 
 const PreviewCard = ({ content }: { content: IPreviewCard }) => {
   const { title, subtitle, data, note, link, category, iconsvg } = content;
-  console.log("--- DEBUG PREVIEW CARD ---");
-  console.log("Título:", content.title);
-  console.log("IconSVG completo:", content.iconsvg);
 
   return (
     <Link href={link || ""}>

--- a/src/components/PreviewCard/PreviewCard.tsx
+++ b/src/components/PreviewCard/PreviewCard.tsx
@@ -4,7 +4,7 @@ import { macroThemes } from "@/utils/constants";
 import Link from "next/link";
 
 const PreviewCard = ({ content }: { content: IPreviewCard }) => {
-  const { title, subtitle, data, note, link, category } = content;
+  const { title, subtitle, data, note, link, category, iconsvg } = content;
 
   return (
     <Link href={link || ""}>
@@ -14,11 +14,23 @@ const PreviewCard = ({ content }: { content: IPreviewCard }) => {
             className="flex items-center justify-center rounded-sm min-w-[40px] w-[40px] h-[40px]"
             style={{ backgroundColor: category.color }}
           >
-            <Icon
-              className="text-white"
-              id={macroThemes[category.id]}
-              size={20}
-            />
+            {iconsvg?.url ? (
+              <img
+                src={
+                  iconsvg.url.startsWith("//")
+                    ? `https:${iconsvg.url}`
+                    : iconsvg.url
+                }
+                alt={title}
+                className="w-5 h-5 object-contain"
+              />
+            ) : (
+              <Icon
+                className="text-white"
+                id={macroThemes[category.id] || "default"}
+                size={20}
+              />
+            )}
           </div>
           <div className="flex flex-col w-full">
             <h3 className="text-sm">{title}</h3>

--- a/src/components/PreviewCard/PreviewCard.tsx
+++ b/src/components/PreviewCard/PreviewCard.tsx
@@ -5,6 +5,9 @@ import Link from "next/link";
 
 const PreviewCard = ({ content }: { content: IPreviewCard }) => {
   const { title, subtitle, data, note, link, category, iconsvg } = content;
+  console.log("--- DEBUG PREVIEW CARD ---");
+  console.log("Título:", content.title);
+  console.log("IconSVG completo:", content.iconsvg);
 
   return (
     <Link href={link || ""}>

--- a/src/components/PreviewSection/PreviewContent.tsx
+++ b/src/components/PreviewSection/PreviewContent.tsx
@@ -20,17 +20,45 @@ interface PreviewContentProps {
 const PreviewContent = ({ header, cards }: PreviewContentProps) => {
   const [selectedState, setSelectedState] = useState("all");
 
-  const allCardsData = cards.map((card) => ({
-    category: card.category,
-    ...card.jsonFile,
-  }));
+  const allCardsData = cards.map((card) => {
+    const json = (card as any).jsonFile ?? {};
+
+    const normalizedStates = (json.states ?? []).map((s: any) => ({
+      ...s,
+      icon: s.icon ?? s.icons ?? s.iconsvg ?? undefined,
+      iconsvg: s.iconsvg ?? s.iconsvg ?? s.icon_svg ?? undefined,
+      iconUrl: s.iconUrl ?? s.iconurl ?? s.icon_url ?? undefined,
+    }));
+
+    return {
+      category: card.category,
+      ...json,
+      states: normalizedStates,
+      icon: (card as any).icon ?? (card as any).icons ?? json.icon ?? undefined,
+      iconsvg:
+        (card as any).iconsvg ??
+        (card as any).iconsvg ??
+        json.iconsvg ??
+        json.iconsvg ??
+        undefined,
+      iconUrl:
+        (card as any).iconUrl ??
+        (card as any).iconurl ??
+        json.iconUrl ??
+        json.iconurl ??
+        undefined,
+    } as any;
+  });
 
   const filteredCards = useMemo(() => {
     return allCardsData.map((regionData) => {
-      const source =
-        selectedState !== "all"
-          ? regionData.states.find((state) => state.name === selectedState)
-          : regionData;
+      const foundState = regionData.states?.find(
+        (state: any) => state.name === selectedState,
+      );
+      const source = selectedState !== "all" ? foundState : regionData;
+
+      const stateSource =
+        selectedState !== "all" ? foundState : regionData.states?.[0];
 
       return source
         ? {
@@ -40,6 +68,18 @@ const PreviewContent = ({ header, cards }: PreviewContentProps) => {
             link: source.link,
             note: source.note,
             category: regionData.category,
+            icon:
+              (stateSource as any)?.icon ??
+              (regionData as any).icon ??
+              undefined,
+            iconsvg:
+              (stateSource as any)?.iconsvg ??
+              (regionData as any).iconsvg ??
+              undefined,
+            iconUrl:
+              (stateSource as any)?.iconUrl ??
+              (regionData as any).iconUrl ??
+              undefined,
           }
         : null;
     }) as IPreviewCard[];
@@ -63,7 +103,7 @@ const PreviewContent = ({ header, cards }: PreviewContentProps) => {
             <SelectGroup>
               <SelectLabel>Estados</SelectLabel>
               {allCardsData &&
-                allCardsData[0].states.map((state, i) => (
+                allCardsData[0].states.map((state: any, i: number) => (
                   <SelectItem value={state.name} key={i}>
                     {state.name}
                   </SelectItem>

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -102,6 +102,7 @@ export interface IPreviewCard {
   link: string;
   data: string;
   note?: string;
+  iconsvg?: { url: string };
 }
 
 export interface IPreviewCards {

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -78,6 +78,9 @@ export const MAIN_PAGE_QUERY = `
           id
           color
         }
+        iconsvg {  
+              url
+        }
       }
     }
 

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -79,7 +79,7 @@ export const MAIN_PAGE_QUERY = `
           color
         }
         iconsvg {  
-              url
+            url
         }
       }
     }
@@ -427,6 +427,9 @@ export const MACROTHEME_PAGE_QUERY = `
       items {
         title
         jsonFile
+        iconsvg {
+          url
+        }
         category {
           name
           id


### PR DESCRIPTION
## Description

This PR changes somes icons on the preview cards on macro themes page based on figma 

<img width="1394" height="602" alt="boa" src="https://github.com/user-attachments/assets/48c7b8eb-18f2-47f2-bf84-a93064670c44" />


Hos to test it:
1. Run the project
2. Go to any macho theme on "Explorar Dados" located on the main page header
3. Check if the preview card icons are distinct from each other 