### PR TITLE
fix: ajusts icon size on the mainbanner macrotheme page

### DIFF
--- a/src/components/MacroThemeBanner/MacroThemeBanner.tsx
+++ b/src/components/MacroThemeBanner/MacroThemeBanner.tsx
@@ -50,9 +50,9 @@ export function MacroThemeBanner({
                 >
                   <Icon
                     id={iconId}
-                    width={184}
-                    height={184}
-                    className="h-24 w-24 text-white sm:h-32 sm:w-32 lg:h-[184px] lg:w-[184px]"
+                    width={168}
+                    height={117}
+                    className="h-40 lg:h-32 w-40 lg:w-32 filter brightness-0 invert opacity-100"
                   />
                 </div>
 


### PR DESCRIPTION
## Description

This PR provides a minor fix to the icon size on the macro themes' main banner:

Before:
<img width="235" height="277" alt="image" src="https://github.com/user-attachments/assets/5c2d3f65-6c81-4d7e-954a-3fb2a8e156ad" />


Now:
<img width="235" height="277" alt="image" src="https://github.com/user-attachments/assets/0357ca5a-49cb-40bf-9bb5-1ac4ce339765" />

How to test it:

1. Run the project;
2. Verify the icon size on the main banner of the macro themes pages.
