### PR TITLE
Feat/explore search filters

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -21,18 +21,35 @@ export const metadata: Metadata = buildMetadata({
 const SEARCH_PAGE_LIMIT = 100;
 
 type SearchPageProps = {
-  searchParams: Promise<{ q?: string | string[] }>;
+  searchParams: Promise<{
+    q?: string | string[];
+    type?: string | string[];
+    themes?: string | string[];
+  }>;
 };
 
 export default async function SearchPage({ searchParams }: SearchPageProps) {
-  const { q } = await searchParams;
+  const { q, type, themes } = await searchParams;
   const query = Array.isArray(q) ? q[0] || "" : q || "";
   const normalizedQuery = normalizeSearchText(query);
   const canSearch = normalizedQuery.length >= MIN_SEARCH_QUERY_LENGTH;
   const index = canSearch ? await getSearchIndex() : null;
-  const results = index
+  let results = index
     ? searchItems(index.items, query, { limit: SEARCH_PAGE_LIMIT })
     : [];
+
+  if (type === "panels") {
+    results = results.filter((r) =>
+      ["data-panel", "data-panel-detail"].includes(r.type),
+    );
+  }
+
+  const selectedThemes = typeof themes === "string" ? themes.split(",") : [];
+  if (selectedThemes.length > 0) {
+    results = results.filter((r) =>
+      r.themes?.some((t) => selectedThemes.includes(t)),
+    );
+  }
   const groups = groupResults(results);
 
   return (

--- a/src/components/ExploreFilters/ExploreFilters.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.tsx
@@ -137,6 +137,19 @@ export function ExploreFilters({
     [selectedThemeNames],
   );
 
+  const handleSearchSubmit = useCallback(
+    (query: string) => {
+      const themeParams =
+        selectedThemeNames.length > 0
+          ? `&themes=${encodeURIComponent(selectedThemeNames.join(","))}`
+          : "";
+      router.push(
+        `/search?q=${encodeURIComponent(query)}&type=panels${themeParams}`,
+      );
+    },
+    [router, selectedThemeNames],
+  );
+
   const updateUrl = useCallback(
     (updates: Record<string, string | null>) => {
       const newParams = new URLSearchParams(params.toString());
@@ -193,6 +206,7 @@ export function ExploreFilters({
                 placeholder="Buscar conteúdo"
                 hideViewAll={true}
                 filterItems={handleFilterItems}
+                onSubmit={handleSearchSubmit}
               />
             )}
 
@@ -356,6 +370,7 @@ export function ExploreFilters({
           className="w-full"
           hideViewAll={true}
           filterItems={handleFilterItems}
+          onSubmit={handleSearchSubmit}
         />
 
         <Button

--- a/src/components/ExploreFilters/ExploreFilters.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "../ui/select";
 import type { MacroTheme } from "@/utils/interfaces";
+import type { SearchIndexItem } from "@/features/search/types";
 
 interface ThemeFilterCardProps {
   iconId: string;
@@ -109,6 +110,32 @@ export function ExploreFilters({
   );
 
   const currentSort = params.get("sort") || sortingTypes["Mais recente"];
+  const selectedThemeNames = useMemo(() => {
+    return themes
+      .filter((theme) => {
+        const themeValue =
+          categoryValues?.[theme.sys.id] ??
+          (categoryValue === "theme-id" ? theme.id : theme.sys.id);
+
+        return selectedCategories.includes(themeValue);
+      })
+      .map((t) => t.name);
+  }, [themes, selectedCategories, categoryValues, categoryValue]);
+
+  const handleFilterItems = useCallback(
+    (item: SearchIndexItem) => {
+      const isPanel = ["data-panel", "data-panel-detail"].includes(item.type);
+
+      if (!isPanel) return false;
+
+      if (selectedThemeNames.length === 0) return true;
+
+      return item.themes.some((themeName) =>
+        selectedThemeNames.includes(themeName),
+      );
+    },
+    [selectedThemeNames],
+  );
 
   const updateUrl = useCallback(
     (updates: Record<string, string | null>) => {
@@ -164,6 +191,8 @@ export function ExploreFilters({
                 variant="page"
                 className="flex-1 max-w-none"
                 placeholder="Buscar conteúdo"
+                hideViewAll={true}
+                filterItems={handleFilterItems}
               />
             )}
 
@@ -322,7 +351,12 @@ export function ExploreFilters({
           </div>
         </div>
 
-        <SearchBar variant="page" className="w-full" />
+        <SearchBar
+          variant="page"
+          className="w-full"
+          hideViewAll={true}
+          filterItems={handleFilterItems}
+        />
 
         <Button
           className="bg-[#018F39] hover:bg-[#018F39]/90 text-[#F8F7F8] h-10 rounded-md w-full"

--- a/src/components/ExploreFilters/ExploreFilters.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.tsx
@@ -261,10 +261,6 @@ export function ExploreFilters({
 
   const handleFilterItems = useCallback(
     (item: SearchIndexItem) => {
-      const isPanel = ["data-panel", "data-panel-detail"].includes(item.type);
-
-      if (!isPanel) return false;
-
       if (selectedThemeNames.length === 0) return true;
 
       return item.themes.some((themeName) =>
@@ -272,19 +268,6 @@ export function ExploreFilters({
       );
     },
     [selectedThemeNames],
-  );
-
-  const handleSearchSubmit = useCallback(
-    (query: string) => {
-      const themeParams =
-        selectedThemeNames.length > 0
-          ? `&themes=${encodeURIComponent(selectedThemeNames.join(","))}`
-          : "";
-      router.push(
-        `/search?q=${encodeURIComponent(query)}&type=panels${themeParams}`,
-      );
-    },
-    [router, selectedThemeNames],
   );
 
   const openSeeThemesModal = () => {
@@ -373,7 +356,8 @@ export function ExploreFilters({
                 placeholder="Buscar conteúdo"
                 hideViewAll={true}
                 filterItems={handleFilterItems}
-                onSubmit={handleSearchSubmit}
+                onSubmit={(q) => updateUrl({ q: q || null, page: "1" })}
+                onQueryChange={(q) => updateUrl({ q: q || null, page: "1" })}
               />
             )}
 
@@ -563,7 +547,8 @@ export function ExploreFilters({
           className="w-full"
           hideViewAll={true}
           filterItems={handleFilterItems}
-          onSubmit={handleSearchSubmit}
+          onSubmit={(q) => updateUrl({ q: q || null, page: "1" })}
+          onQueryChange={(q) => updateUrl({ q: q || null, page: "1" })}
         />
 
         <Button

--- a/src/components/ExploreFilters/ExploreFilters.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.tsx
@@ -355,6 +355,7 @@ export function ExploreFilters({
                 className="flex-1 max-w-none"
                 placeholder="Buscar conteúdo"
                 hideViewAll={true}
+                hideSuggestions={true}
                 filterItems={handleFilterItems}
                 onSubmit={(q) => updateUrl({ q: q || null, page: "1" })}
                 onQueryChange={(q) => updateUrl({ q: q || null, page: "1" })}
@@ -546,6 +547,7 @@ export function ExploreFilters({
           variant="page"
           className="w-full"
           hideViewAll={true}
+          hideSuggestions={true}
           filterItems={handleFilterItems}
           onSubmit={(q) => updateUrl({ q: q || null, page: "1" })}
           onQueryChange={(q) => updateUrl({ q: q || null, page: "1" })}

--- a/src/components/Posts/Posts.tsx
+++ b/src/components/Posts/Posts.tsx
@@ -77,6 +77,7 @@ export const Posts = ({
           pages={pages}
           posts={posts}
           loading={loading}
+          searchQuery={filter.q as string}
         />
       </div>
     </section>

--- a/src/components/PostsGrid/PostsGrid.tsx
+++ b/src/components/PostsGrid/PostsGrid.tsx
@@ -11,11 +11,13 @@ export const PostsGrid = ({
   pages,
   posts = [],
   loading,
+  searchQuery,
 }: {
   currentPage: number;
   loading: boolean;
   pages: number;
   posts: IPublication[];
+  searchQuery?: string;
 }) => (
   <div className="grow-1 flex flex-col items-center gap-8 w-full max-w-[1440px]">
     <div
@@ -33,7 +35,11 @@ export const PostsGrid = ({
       ) : (
         <div className="grow-1 flex flex-col gap-4 justify-center items-center w-full py-12 bg-gray-50 rounded-lg">
           <Icon id="no-mail" size={48} />
-          <span>Nenhum post encontrado</span>
+          <span>
+            {searchQuery
+              ? `Nenhum resultado para "${searchQuery}"`
+              : "Nenhum post encontrado"}
+          </span>
         </div>
       )}
     </div>

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -37,6 +37,7 @@ type SearchBarProps = {
   hideViewAll?: boolean;
   filterItems?: (item: SearchIndexItem) => boolean;
   onSubmit?: (query: string) => void;
+  onQueryChange?: (query: string) => void;
 };
 
 export const SearchBar = ({
@@ -49,6 +50,7 @@ export const SearchBar = ({
   hideViewAll = false,
   filterItems,
   onSubmit,
+  onQueryChange,
 }: SearchBarProps) => {
   const router = useRouter();
   const [query, setQuery] = useState(initialQuery);
@@ -58,6 +60,7 @@ export const SearchBar = ({
   const [open, setOpen] = useState(false);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
   const isMountedRef = useRef(true);
+  const pendingUpdate = useRef<ReturnType<typeof setTimeout>>();
   const inputId = useId();
 
   useEffect(() => {
@@ -69,6 +72,7 @@ export const SearchBar = ({
 
     return () => {
       isMountedRef.current = false;
+      if (pendingUpdate.current) clearTimeout(pendingUpdate.current);
     };
   }, []);
 
@@ -109,13 +113,14 @@ export const SearchBar = ({
 
   const submitSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!query.trim()) return;
+    if (pendingUpdate.current) clearTimeout(pendingUpdate.current);
 
     setOpen(false);
     onNavigate?.();
     if (onSubmit) {
       onSubmit(query.trim());
     } else {
+      if (!query.trim()) return;
       router.push(`/search?q=${encodeURIComponent(query.trim())}`);
     }
   };
@@ -126,6 +131,13 @@ export const SearchBar = ({
 
     if (normalizeSearchText(value).length >= MIN_SEARCH_QUERY_LENGTH) {
       void loadIndex();
+    }
+
+    if (onQueryChange) {
+      if (pendingUpdate.current) clearTimeout(pendingUpdate.current);
+      pendingUpdate.current = setTimeout(() => {
+        onQueryChange(value.trim());
+      }, 300);
     }
   };
 

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -36,6 +36,7 @@ type SearchBarProps = {
   variant?: "header" | "mobile" | "page";
   hideViewAll?: boolean;
   filterItems?: (item: SearchIndexItem) => boolean;
+  onSubmit?: (query: string) => void;
 };
 
 export const SearchBar = ({
@@ -47,6 +48,7 @@ export const SearchBar = ({
   variant = "header",
   hideViewAll = false,
   filterItems,
+  onSubmit,
 }: SearchBarProps) => {
   const router = useRouter();
   const [query, setQuery] = useState(initialQuery);
@@ -111,7 +113,11 @@ export const SearchBar = ({
 
     setOpen(false);
     onNavigate?.();
-    router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+    if (onSubmit) {
+      onSubmit(query.trim());
+    } else {
+      router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+    }
   };
 
   const handleQueryChange = (value: string) => {

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -38,6 +38,7 @@ type SearchBarProps = {
   filterItems?: (item: SearchIndexItem) => boolean;
   onSubmit?: (query: string) => void;
   onQueryChange?: (query: string) => void;
+  hideSuggestions?: boolean;
 };
 
 export const SearchBar = ({
@@ -51,6 +52,7 @@ export const SearchBar = ({
   filterItems,
   onSubmit,
   onQueryChange,
+  hideSuggestions = false,
 }: SearchBarProps) => {
   const router = useRouter();
   const [query, setQuery] = useState(initialQuery);
@@ -129,7 +131,10 @@ export const SearchBar = ({
     setQuery(value);
     setOpen(true);
 
-    if (normalizeSearchText(value).length >= MIN_SEARCH_QUERY_LENGTH) {
+    if (
+      !hideSuggestions &&
+      normalizeSearchText(value).length >= MIN_SEARCH_QUERY_LENGTH
+    ) {
       void loadIndex();
     }
 
@@ -141,7 +146,8 @@ export const SearchBar = ({
     }
   };
 
-  const showPanel = open && (canSearch || status === "loading");
+  const showPanel =
+    !hideSuggestions && open && (canSearch || status === "loading");
 
   const handleBlur = (event: FocusEvent<HTMLFormElement>) => {
     const nextFocused = event.relatedTarget;
@@ -192,7 +198,7 @@ export const SearchBar = ({
             onChange={(event) => handleQueryChange(event.target.value)}
             onFocus={() => {
               setOpen(true);
-              void loadIndex();
+              if (!hideSuggestions) void loadIndex();
             }}
             placeholder={placeholder}
             type="search"

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -34,6 +34,8 @@ type SearchBarProps = {
   onNavigate?: () => void;
   placeholder?: string;
   variant?: "header" | "mobile" | "page";
+  hideViewAll?: boolean;
+  filterItems?: (item: SearchIndexItem) => boolean;
 };
 
 export const SearchBar = ({
@@ -43,6 +45,8 @@ export const SearchBar = ({
   onNavigate,
   placeholder = "Buscar conteúdo",
   variant = "header",
+  hideViewAll = false,
+  filterItems,
 }: SearchBarProps) => {
   const router = useRouter();
   const [query, setQuery] = useState(initialQuery);
@@ -68,13 +72,12 @@ export const SearchBar = ({
 
   const normalizedQuery = normalizeSearchText(query);
   const canSearch = normalizedQuery.length >= MIN_SEARCH_QUERY_LENGTH;
-  const suggestions = useMemo(
-    () =>
-      items && canSearch
-        ? searchItems(items, query, { limit: DEFAULT_SEARCH_LIMIT })
-        : [],
-    [canSearch, items, query],
-  );
+  const suggestions = useMemo(() => {
+    if (!items || !canSearch) return [];
+    const filteredItems = filterItems ? items.filter(filterItems) : items;
+
+    return searchItems(filteredItems, query, { limit: DEFAULT_SEARCH_LIMIT });
+  }, [canSearch, items, query, filterItems]);
 
   const loadIndex = useCallback(async () => {
     if (items) {
@@ -104,7 +107,7 @@ export const SearchBar = ({
 
   const submitSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!canSearch) return;
+    if (!query.trim()) return;
 
     setOpen(false);
     onNavigate?.();
@@ -180,7 +183,7 @@ export const SearchBar = ({
           <button
             aria-label="Buscar"
             className="flex size-4 items-center justify-center text-[#292829] transition hover:text-green-900 disabled:cursor-not-allowed disabled:opacity-40"
-            disabled={!canSearch}
+            disabled={!query.trim()}
             type="submit"
           >
             <Search className="size-4" aria-hidden="true" />
@@ -219,7 +222,9 @@ export const SearchBar = ({
                       className="flex flex-col gap-1 px-4 py-3 text-left transition hover:bg-green-neutro focus:bg-green-neutro focus:outline-none"
                       href={item.href}
                       key={item.id}
+                      onMouseDown={(e) => e.preventDefault()}
                       onClick={() => {
+                        setQuery(item.title);
                         setOpen(false);
                         onNavigate?.();
                       }}
@@ -244,17 +249,20 @@ export const SearchBar = ({
                 </div>
               )}
 
-              <Link
-                className="flex items-center justify-between border-t border-grey-200 px-4 py-3 text-sm font-semibold text-green-900 transition hover:bg-green-neutro focus:bg-green-neutro focus:outline-none"
-                href={`/search?q=${encodeURIComponent(query.trim())}`}
-                onClick={() => {
-                  setOpen(false);
-                  onNavigate?.();
-                }}
-              >
-                Ver todos os resultados
-                <Search className="size-4" aria-hidden="true" />
-              </Link>
+              {!hideViewAll && (
+                <Link
+                  className="flex items-center justify-between border-t border-grey-200 px-4 py-3 text-sm font-semibold text-green-900 transition hover:bg-green-neutro focus:bg-green-neutro focus:outline-none"
+                  href={`/search?q=${encodeURIComponent(query.trim())}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    setOpen(false);
+                    onNavigate?.();
+                  }}
+                >
+                  Ver todos os resultados
+                  <Search className="size-4" aria-hidden="true" />
+                </Link>
+              )}
             </>
           )}
         </div>

--- a/src/features/posts/filters.ts
+++ b/src/features/posts/filters.ts
@@ -41,12 +41,14 @@ export const parsePostsFilters = (
     }
 
     const formattedForm = exploreFilterMap[key].formatForm(value);
-    if (formattedForm[key]) {
-      contentfulFilter = {
-        ...contentfulFilter,
-        [key]: formattedForm[key],
-      };
-    }
+    Object.entries(formattedForm).forEach(([fKey, fValue]) => {
+      if (fValue !== undefined) {
+        contentfulFilter = {
+          ...contentfulFilter,
+          [fKey]: fValue,
+        };
+      }
+    });
   });
 
   return { contentfulFilter, urlParams };
@@ -67,6 +69,7 @@ export const parsePostsQueryState = (
       category: parsePostsListParam(params.get("category")) ?? [],
       date_lte: parsePostsDateParam(params.get("date_lte")),
       date_gte: parsePostsDateParam(params.get("date_gte")),
+      q: params.get("q") || undefined,
     },
   };
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -169,4 +169,27 @@ export const exploreFilterMap: { [key: string]: ExploreFilterFormatter } = {
       };
     },
   },
+  q: {
+    name: "title_contains",
+    formatForm: (params: FilterFormValue) => {
+      const q =
+        typeof params === "string"
+          ? params
+          : Array.isArray(params)
+            ? params[0]
+            : "";
+
+      return q ? { title_contains: q } : { title_contains: undefined };
+    },
+    formatParam: (params: FilterFormValue) => {
+      const q =
+        typeof params === "string"
+          ? params
+          : Array.isArray(params)
+            ? params[0]
+            : "";
+
+      return { q: q || null };
+    },
+  },
 };


### PR DESCRIPTION
##Description

This PR fixes the search behavior when originating from the Explore page, applies theme filtering to the search suggestions, and fixes suggestion click interactions.

## How to test it

1. Run the project;
2. Navigate to the Explore page (/explore);
3. Select a theme filter and type a keyword in the search bar;
4. Verify that the search suggestions dropdown only shows items relevant to the selected themes;
5. Click on a suggestion to verify that the click interaction works properly;
6. Alternatively, press Enter to submit the search;
7. Verify that the search results page only displays the "Painéis" section, accurately reflecting the typed keyword and selected theme filters.