### PR TITLE
Fix/align layout

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -174,19 +174,19 @@ export default async function ExplorePage({
       sm:items-end sm:px-6 sm:pb-6 sm:pt-0
       lg:px-20 lg:pb-12"
         >
-          <div className="flex flex-col gap-4 lg:gap-2 w-full max-w-[1280px]">
-            <h1 className="text-[30px] lg:text-[48px] font-extrabold leading-[36px] lg:leading-[48px] tracking-[-0.0075em] text-[#F8F7F8]">
+          <div className="flex flex-col gap-4 sm:gap-6 w-full max-w-[1280px]">
+            <h1 className="text-[30px] sm:text-[48px] font-extrabold leading-[36px] sm:leading-[48px] tracking-[-0.0075em] sm:tracking-[-0.012em] text-[#F8F7F8]">
               {pageHeaders.items[0]?.title}
             </h1>
 
             {pageHeaders.items[0]?.richSubtitle ? (
-              <div className="text-[14px] font-normal leading-[21px] text-[#F8F7F8] [&_p]:m-0">
+              <div className="text-[14px] sm:text-[16px] font-normal sm:font-medium leading-[21px] sm:leading-6 text-[#F8F7F8] [&_p]:m-0">
                 {documentToReactComponents(
                   pageHeaders.items[0].richSubtitle.json,
                 )}
               </div>
             ) : pageHeaders.items[0]?.subtitle ? (
-              <p className="text-[14px] font-normal leading-[21px] text-[#F8F7F8]">
+              <p className="text-[14px] sm:text-[16px] font-normal sm:font-medium leading-[21px] sm:leading-6 text-[#F8F7F8]">
                 {pageHeaders.items[0].subtitle}
               </p>
             ) : null}

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,4 +1,3 @@
-import PageHeader from "@/components/PageHeader/PageHeader";
 import { Posts } from "@/components/Posts/Posts";
 import { ExploreFilters } from "@/components/ExploreFilters/ExploreFilters";
 import { MacroThemeTabs } from "@/components/MacroThemeTabs/MacroThemeTabs";
@@ -16,6 +15,7 @@ import {
   buildPostsTotalPages,
   parsePostsQueryState,
 } from "@/features/posts/filters";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 
 export const metadata: Metadata = buildMetadata({
   title: "Explorar",
@@ -105,8 +105,63 @@ export default async function ExplorePage({
 
   return (
     <HubTemplate>
-      <PageHeader content={pageHeaders.items[0]} />
-      <div className="pt-6 sm:pt-12" />
+      <section className="relative w-full overflow-hidden h-[226px] sm:h-[200px] lg:h-[220px]">
+        <div
+          className="absolute inset-0 bg-cover bg-no-repeat"
+          style={
+            pageHeaders.items[0]?.banner?.url
+              ? {
+                  backgroundImage: `url(${pageHeaders.items[0].banner.url})`,
+                  backgroundPosition: "center 35%",
+                }
+              : undefined
+          }
+        />
+
+        <div
+          className="absolute inset-0 sm:hidden"
+          style={{
+            background:
+              "linear-gradient(359.78deg, rgba(0,0,0,0.92) 0.2%, rgba(0,0,0,0) 195.14%)",
+          }}
+        />
+
+        <div
+          className="absolute inset-0 hidden sm:block"
+          style={{
+            background: `
+        linear-gradient(90deg, #000000 14.27%, rgba(102,102,102,0) 31.53%),
+        linear-gradient(0deg, rgba(0,0,0,0.92) -41.89%, rgba(0,0,0,0) 195.68%)
+      `,
+          }}
+        />
+
+        <div
+          className="relative z-10 flex w-full h-full max-w-[1440px] mx-auto
+      items-start p-6
+      sm:items-end sm:px-6 sm:pb-6 sm:pt-0
+      lg:px-20 lg:pb-12"
+        >
+          <div className="flex flex-col gap-4 lg:gap-2 w-full max-w-[1280px]">
+            <h1 className="text-[30px] lg:text-[48px] font-extrabold leading-[36px] lg:leading-[48px] tracking-[-0.0075em] text-[#F8F7F8]">
+              {pageHeaders.items[0]?.title}
+            </h1>
+
+            {pageHeaders.items[0]?.richSubtitle ? (
+              <div className="text-[14px] font-normal leading-[21px] text-[#F8F7F8] [&_p]:m-0">
+                {documentToReactComponents(
+                  pageHeaders.items[0].richSubtitle.json,
+                )}
+              </div>
+            ) : pageHeaders.items[0]?.subtitle ? (
+              <p className="text-[14px] font-normal leading-[21px] text-[#F8F7F8]">
+                {pageHeaders.items[0].subtitle}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </section>
+      <div className="pt-4 sm:pt-6" />
       <ExploreFilters themes={themes.items} />
       <div className="h-4 sm:h-6" />
       <section className="w-full bg-[#F8F7F8]">

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -56,6 +56,10 @@ interface IInitialPostsContent {
   postCollection: { total: number; items: IPublication[] };
 }
 
+interface IPostsCount {
+  postCollection: { total: number };
+}
+
 export default async function ExplorePage({
   searchParams,
 }: {
@@ -89,6 +93,34 @@ export default async function ExplorePage({
     header_id: "panels",
     head_id: "interactive-panels",
   });
+
+  const [dashboardsPosts, datastoriesPosts, boletinsPosts] = await Promise.all([
+    getContent<IPostsCount>(PUBLICATION_QUERY, {
+      order: initialQueryState.sorting,
+      skip: 0,
+      limit: 1,
+      filter: buildPostsContentfulFilter(initialQueryState.filter, {
+        type_in: "data-panel",
+      }),
+    }),
+    getContent<IPostsCount>(PUBLICATION_QUERY, {
+      order: initialQueryState.sorting,
+      skip: 0,
+      limit: 1,
+      filter: buildPostsContentfulFilter(initialQueryState.filter, {
+        type_in: "data-story",
+      }),
+    }),
+    getContent<IPostsCount>(PUBLICATION_QUERY, {
+      order: initialQueryState.sorting,
+      skip: 0,
+      limit: 1,
+      filter: buildPostsContentfulFilter(initialQueryState.filter, {
+        type_in: ["newsletter", "additional-content"],
+      }),
+    }),
+  ]);
+
   const { postCollection: initialPosts }: IInitialPostsContent =
     await getContent(PUBLICATION_QUERY, {
       order: initialQueryState.sorting,
@@ -167,9 +199,21 @@ export default async function ExplorePage({
       <section className="w-full bg-[#F8F7F8]">
         <Suspense>
           <MacroThemeTabs
-            dashboards={[]}
-            datastories={[]}
-            publicacoes={[]}
+            dashboards={
+              dashboardsPosts.postCollection.total > 0
+                ? Array(dashboardsPosts.postCollection.total).fill(undefined)
+                : []
+            }
+            datastories={
+              datastoriesPosts.postCollection.total > 0
+                ? Array(datastoriesPosts.postCollection.total).fill(undefined)
+                : []
+            }
+            publicacoes={
+              boletinsPosts.postCollection.total > 0
+                ? Array(boletinsPosts.postCollection.total).fill(undefined)
+                : []
+            }
             headers={{
               dashboards: tabHeadersById.get("dashboards"),
               datastories: tabHeadersById.get("datastories"),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Lato } from "next/font/google";
+import { Inter } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import {
   buildMetadata,
@@ -11,8 +11,8 @@ import {
 import "./globals.css";
 
 const NEXT_PUBLIC_GA_ID = process.env.NEXT_PUBLIC_GA_ID ?? "";
-const lato = Lato({
-  weight: ["400", "700", "900"],
+const inter = Inter({
+  weight: ["400", "500", "600", "700", "800", "900"],
   subsets: ["latin"],
   style: ["normal", "italic"],
 });
@@ -64,7 +64,7 @@ export default function RootLayout({
   return (
     <html lang="pt-br">
       <link rel="icon" href="/favicon.ico" sizes="any" />
-      <body className={lato.className}>{children}</body>
+      <body className={inter.className}>{children}</body>
 
       <GoogleAnalytics gaId={NEXT_PUBLIC_GA_ID} />
     </html>

--- a/src/components/ExploreFilters/ExploreFilters.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.tsx
@@ -22,10 +22,13 @@ import {
 import type { MacroTheme } from "@/utils/interfaces";
 import { XIcon } from "lucide-react";
 
+import Link from "next/link";
+
 interface ThemeFilterCardProps {
   iconId: string;
   color: string;
   name: string;
+  href?: string;
   checked?: boolean;
   onCheckedChange?: (checked: boolean) => void;
 }
@@ -34,6 +37,7 @@ function ThemeFilterCard({
   iconId,
   color,
   name,
+  href,
   checked,
   onCheckedChange,
 }: ThemeFilterCardProps) {
@@ -53,19 +57,35 @@ function ThemeFilterCard({
 
       <div className="w-px h-full bg-[#EFEFEF]" />
 
-      <div className="flex items-center gap-2 flex-1 h-full px-2 rounded-r-lg hover:bg-[#DDEADF] transition-colors">
-        <Icon id={iconId} size={16} style={{ color }} />
-
-        <span className="flex-1 text-sm font-normal text-[#292829] truncate">
-          {name}
-        </span>
-
-        <Icon
-          className="text-[#999999] flex-shrink-0 rotate-270"
-          id="expand"
-          size={12}
-        />
-      </div>
+      {href ? (
+        <Link
+          href={href}
+          className="flex items-center gap-2 flex-1 h-full px-2 rounded-r-lg hover:bg-[#DDEADF] transition-colors"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Icon id={iconId} size={16} style={{ color }} />
+          <span className="flex-1 text-sm font-normal text-[#292829] truncate">
+            {name}
+          </span>
+          <Icon
+            className="text-[#999999] flex-shrink-0 rotate-270"
+            id="expand"
+            size={12}
+          />
+        </Link>
+      ) : (
+        <div className="flex items-center gap-2 flex-1 h-full px-2 rounded-r-lg hover:bg-[#DDEADF] transition-colors">
+          <Icon id={iconId} size={16} style={{ color }} />
+          <span className="flex-1 text-sm font-normal text-[#292829] truncate">
+            {name}
+          </span>
+          <Icon
+            className="text-[#999999] flex-shrink-0 rotate-270"
+            id="expand"
+            size={12}
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -427,6 +447,7 @@ export function ExploreFilters({
                   iconId={MACROTHEME_ICON_BY_ID[iconKey] || "list"}
                   color={theme.color || "#999999"}
                   name={theme.name}
+                  href={`/macrothemes/${theme.id.replace(/_/g, "-")}`}
                   checked={selectedCategories.includes(themeValue)}
                   onCheckedChange={() => toggleCategory(themeValue)}
                 />

--- a/src/components/ExploreFilters/ExploreFilters.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "../ui/select";
 import type { MacroTheme } from "@/utils/interfaces";
+import { XIcon } from "lucide-react";
 
 interface ThemeFilterCardProps {
   iconId: string;
@@ -38,7 +39,7 @@ function ThemeFilterCard({
 }: ThemeFilterCardProps) {
   return (
     <div
-      className="flex flex-row h-8 sm:w-[302px] bg-[#F8F7F8] border border-[#EFEFEF] rounded-lg cursor-pointer hover:bg-[#F0EFEF] transition-colors flex-shrink-0 overflow-hidden"
+      className="flex flex-row h-8 sm:w-[302px] bg-[#F8F7F8] border border-[#EFEFEF] rounded-lg cursor-pointer hover:bg-[#F0EFEF] transition-colors flex-shrink-0"
       onClick={() => onCheckedChange?.(!checked)}
     >
       <div className="flex items-center justify-center h-full w-8 rounded-l-lg hover:bg-[#DDEADF] transition-colors">
@@ -83,6 +84,107 @@ interface ExploreFiltersProps {
   sortingOptions?: Record<string, string>;
 }
 
+function SeeThemesModal({
+  themes,
+  selectedCategories,
+  onToggleCategory,
+  onClose,
+  onApply,
+}: {
+  themes: Pick<MacroTheme, "id" | "name" | "color" | "sys">[];
+  selectedCategories: string[];
+  onToggleCategory: (themeId: string) => void;
+  onClose: () => void;
+  onApply: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-lg w-full max-w-[393px] max-h-[80vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-col gap-6 p-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-[24px] font-semibold leading-[36px] tracking-[-0.0075em] text-[#292829]">
+              Veja por temas
+            </h2>
+            <button
+              onClick={onClose}
+              className="flex items-center justify-center w-11 h-11 rounded-md hover:bg-grey-100 transition-colors"
+              aria-label="Fechar"
+            >
+              <XIcon className="w-5 h-5 text-[#077432]" />
+            </button>
+          </div>
+
+          <div className="flex flex-col gap-2 overflow-y-auto flex-1">
+            {themes.map((theme) => {
+              const iconKey = normalizeKey(theme.name);
+              const isChecked = selectedCategories.includes(theme.sys.id);
+
+              return (
+                <div
+                  key={theme.sys.id}
+                  className="flex flex-row h-8 bg-[#F8F7F8] border border-[#EFEFEF] rounded-lg cursor-pointer hover:bg-[#F0EFEF] transition-colors flex-shrink-0"
+                  onClick={() => onToggleCategory(theme.sys.id)}
+                >
+                  <div className="flex items-center justify-center h-full w-8 rounded-l-lg hover:bg-[#DDEADF] transition-colors">
+                    <Checkbox
+                      checked={isChecked}
+                      onCheckedChange={() => onToggleCategory(theme.sys.id)}
+                      className="w-4 h-4 border-[#018F39] data-[state=checked]:bg-[#018F39] flex-shrink-0 rounded"
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </div>
+
+                  <div className="w-px h-full bg-[#EFEFEF]" />
+
+                  <div className="flex items-center gap-2 flex-1 h-full px-2 rounded-r-lg hover:bg-[#DDEADF] transition-colors">
+                    <Icon
+                      id={MACROTHEME_ICON_BY_ID[iconKey] || "list"}
+                      size={16}
+                      style={{ color: theme.color || "#999999" }}
+                    />
+
+                    <span className="flex-1 text-sm font-normal text-[#292829] truncate">
+                      {theme.name}
+                    </span>
+
+                    <Icon
+                      className="text-[#999999] flex-shrink-0 rotate-270"
+                      id="expand"
+                      size={12}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="flex flex-row gap-3">
+            <Button
+              variant="secondary"
+              className="flex-1 h-10 bg-white border border-[#EFEFEF] rounded-md text-[#E5333F] hover:bg-grey-100"
+              onClick={onClose}
+            >
+              Cancelar
+            </Button>
+            <Button
+              className="flex-1 h-10 bg-[#018F39] hover:bg-[#018F39]/90 text-[#F8F7F8] rounded-md"
+              onClick={onApply}
+            >
+              Aplicar
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ExploreFilters({
   className,
   themes,
@@ -101,7 +203,8 @@ export function ExploreFilters({
   const pathname = usePathname();
   const mobileThemesId = useId();
   const [mobileThemesOpen, setMobileThemesOpen] = useState(false);
-  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const [seeThemesModalOpen, setSeeThemesModalOpen] = useState(false);
+  const [pendingCategories, setPendingCategories] = useState<string[]>([]);
 
   const selectedCategories = useMemo(
     () => params.get("category")?.split(",").filter(Boolean) ?? [],
@@ -109,6 +212,32 @@ export function ExploreFilters({
   );
 
   const currentSort = params.get("sort") || sortingTypes["Mais recente"];
+
+  const openSeeThemesModal = () => {
+    setPendingCategories(selectedCategories);
+    setSeeThemesModalOpen(true);
+  };
+
+  const closeSeeThemesModal = () => {
+    setSeeThemesModalOpen(false);
+  };
+
+  const applySeeThemesModal = () => {
+    updateUrl({
+      category:
+        pendingCategories.length > 0 ? pendingCategories.join(",") : null,
+      page: "1",
+    });
+    setSeeThemesModalOpen(false);
+  };
+
+  const togglePendingCategory = (themeId: string) => {
+    setPendingCategories((prev) =>
+      prev.includes(themeId)
+        ? prev.filter((id) => id !== themeId)
+        : [...prev, themeId],
+    );
+  };
 
   const updateUrl = useCallback(
     (updates: Record<string, string | null>) => {
@@ -326,10 +455,10 @@ export function ExploreFilters({
 
         <Button
           className="bg-[#018F39] hover:bg-[#018F39]/90 text-[#F8F7F8] h-10 rounded-md w-full"
-          onClick={() => setMobileFiltersOpen((prev) => !prev)}
+          onClick={openSeeThemesModal}
         >
           <Icon id="filter" size={16} className="text-[#F8F7F8]" />
-          <span>Filtrar</span>
+          <span>Veja por temas</span>
         </Button>
 
         <div className="flex flex-row items-center gap-3">
@@ -365,26 +494,17 @@ export function ExploreFilters({
             </SelectContent>
           </Select>
         </div>
-
-        {mobileFiltersOpen && (
-          <div className="flex flex-col gap-2">
-            {themes.map((theme) => {
-              const iconKey = normalizeKey(theme.name);
-
-              return (
-                <ThemeFilterCard
-                  key={theme.sys.id}
-                  iconId={MACROTHEME_ICON_BY_ID[iconKey] || "list"}
-                  color={theme.color || "#999999"}
-                  name={theme.name}
-                  checked={selectedCategories.includes(theme.sys.id)}
-                  onCheckedChange={() => toggleCategory(theme.sys.id)}
-                />
-              );
-            })}
-          </div>
-        )}
       </div>
+
+      {seeThemesModalOpen && (
+        <SeeThemesModal
+          themes={themes}
+          selectedCategories={pendingCategories}
+          onToggleCategory={togglePendingCategory}
+          onClose={closeSeeThemesModal}
+          onApply={applySeeThemesModal}
+        />
+      )}
     </section>
   );
 }

--- a/src/components/Header/Section/HeaderSection.tsx
+++ b/src/components/Header/Section/HeaderSection.tsx
@@ -17,7 +17,7 @@ const HeaderSection = ({ content }: { content: ISection[] }) => {
   ]);
 
   return (
-    <div className="sticky top-0 left-0 z-2 bg-white">
+    <div className="sticky top-0 left-0 z-50 bg-white">
       <div className="xl:hidden w-full h-[80px] flex border-b-2 justify-between px-4 py-[18px]">
         <Suspense>
           <HeaderModal content={orderedContent} />

--- a/src/components/MacroThemeTabs/MacroThemeTabs.tsx
+++ b/src/components/MacroThemeTabs/MacroThemeTabs.tsx
@@ -111,13 +111,14 @@ export function MacroThemeTabs({
     header: IPageHeader | undefined,
     defaultTitle: string,
     href: string,
-    emptyMessage: string,
   ) => {
+    if (items.length === 0) return null;
+
     return (
       <section className="animate-in fade-in duration-300 flex flex-col gap-6">
         <div className="flex items-start justify-between gap-4">
           {renderHeader(header, defaultTitle)}
-          {showViewAll && items.length > 0 && (
+          {showViewAll && (
             <LinkButton
               href={href}
               variant="secondary"
@@ -128,17 +129,11 @@ export function MacroThemeTabs({
             </LinkButton>
           )}
         </div>
-        {items.length > 0 ? (
-          <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {items.map((post, i) => (
-              <ContentPost content={post} key={i} />
-            ))}
-          </div>
-        ) : (
-          <div className="p-8 border-2 border-dashed border-gray-200 rounded-lg text-center text-gray-500">
-            <p>{emptyMessage}</p>
-          </div>
-        )}
+        <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {items.map((post, i) => (
+            <ContentPost content={post} key={i} />
+          ))}
+        </div>
       </section>
     );
   };
@@ -149,6 +144,27 @@ export function MacroThemeTabs({
     { key: "boletins", label: "Boletins" },
   ];
 
+  // Tabs are hidden when their content array is empty. On the explore page
+  // (tabsOnly=true) the arrays are populated from count queries just to
+  // control visibility — actual content is rendered by the Posts component.
+  const availableTabs = tabs.filter((tab) => {
+    if (tab.key === "paineis") {
+      return dashboards.length > 0;
+    }
+    if (tab.key === "datastories") {
+      return datastories.length > 0;
+    }
+    if (tab.key === "boletins") {
+      return publicacoes.length > 0;
+    }
+
+    return false;
+  });
+
+  if (availableTabs.length === 0) {
+    return null;
+  }
+
   return (
     <div className="w-full">
       <div className="w-full bg-white border-b border-[#BEBBBD]">
@@ -157,7 +173,7 @@ export function MacroThemeTabs({
           className="flex flex-row items-stretch gap-4 max-w-[1440px] mx-auto lg:px-20 py-0 overflow-x-auto scrollbar-hide"
           style={{ height: "60px" }}
         >
-          {tabs.map(({ key, label }) => (
+          {availableTabs.map(({ key, label }) => (
             <button
               key={key}
               role="tab"
@@ -199,7 +215,6 @@ export function MacroThemeTabs({
               headers.dashboards,
               "Painel de Dados",
               urls.dashboardsHref,
-              "Ainda não há painéis publicados para este macrotema.",
             )}
           {activeTab === "datastories" &&
             renderTabSection(
@@ -207,7 +222,6 @@ export function MacroThemeTabs({
               headers.datastories,
               "Narrativa de Dados",
               urls.datastoriesHref,
-              "Ainda não há datastories publicados para este macrotema.",
             )}
           {activeTab === "boletins" &&
             renderTabSection(
@@ -215,7 +229,6 @@ export function MacroThemeTabs({
               headers.publications,
               "Publicações",
               urls.postsByThemeHref,
-              "Ainda não há boletins/publicações para este macrotema.",
             )}
         </div>
       )}

--- a/src/components/MacroThemeTabs/MacroThemeTabs.tsx
+++ b/src/components/MacroThemeTabs/MacroThemeTabs.tsx
@@ -145,7 +145,7 @@ export function MacroThemeTabs({
 
   const tabs: { key: TabType; label: string }[] = [
     { key: "paineis", label: "Painéis" },
-    { key: "datastories", label: "Datastories" },
+    { key: "datastories", label: "Narrativas" },
     { key: "boletins", label: "Boletins" },
   ];
 
@@ -154,7 +154,7 @@ export function MacroThemeTabs({
       <div className="w-full bg-white border-b border-[#BEBBBD]">
         <div
           role="tablist"
-          className="flex flex-row items-stretch gap-4 max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-20 py-0 overflow-x-auto scrollbar-hide"
+          className="flex flex-row items-stretch gap-4 max-w-[1440px] mx-auto lg:px-20 py-0 overflow-x-auto scrollbar-hide"
           style={{ height: "60px" }}
         >
           {tabs.map(({ key, label }) => (
@@ -163,10 +163,10 @@ export function MacroThemeTabs({
               role="tab"
               aria-selected={activeTab === key}
               onClick={() => handleTabClick(key)}
-              style={{ padding: "0 12px" }}
-              className={`h-full whitespace-nowrap flex items-center justify-center font-medium text-[14px] leading-5 transition-colors border-b-2 outline-none focus-visible:ring-2 focus-visible:ring-[#018F39] ${
+              style={{ padding: "16px 12px" }}
+              className={`h-full flex items-center justify-center font-medium text-[14px] leading-5 transition-colors border-b-2 outline-none focus-visible:ring-2 focus-visible:ring-[#018F39] ${
                 activeTab === key
-                  ? "border-[#018F39] text-[#018F39] drop-shadow-sm"
+                  ? "border-[#018F39] text-[#018F39]"
                   : "border-transparent text-[#7E797B] hover:text-[#292829] hover:border-gray-300"
               }`}
             >

--- a/src/utils/queries/posts.ts
+++ b/src/utils/queries/posts.ts
@@ -81,6 +81,7 @@ export const EXPLORE_PAGE_QUERY = `
     themeCollection(preview: $preview) {
       items {
         name
+        id
         color
         sys {
           id


### PR DESCRIPTION
## O que essa PR adiciona

**Banner responsivo** — tipografia ajustada conforme Figma: título 30px mobile / 48px desktop, descrição 14px / 16px.

**Navegação nos filtros de tema** — `ThemeFilterCard` recebe `href` opcional; clicar no nome do tema navega para `/macrothemes/{id}`, clicar no checkbox continua filtrando normalmente.

**Query de temas** — campo `id` adicionado ao `themeCollection` na `EXPLORE_PAGE_QUERY` para gerar o slug de navegação.

**Visibilidade dinâmica das tabs** — três queries de contagem (uma por tipo) determinam quais tabs aparecem. Os filtros ativos do usuário (categoria, data) são incluídos nas contagens, então a tab some se não houver resultados para aquele tipo com os filtros aplicados.

**Troca da fonte *Lato* pela *Inter***

---

## Arquivos alterados

- `src/app/explore/page.tsx`
- `src/components/ExploreFilters/ExploreFilters.tsx`
- `src/components/MacroThemeTabs/MacroThemeTabs.tsx`
- `src/utils/queries/posts.ts`

---

## Checklist

- [x] Banner mobile: título 30px, descrição 14px
- [x] Banner desktop: título 48px, descrição 16px
- [x] Clicar no nome do tema navega para a página do macrotema
- [x] Clicar no checkbox filtra sem navegar
- [x] Tab some quando filtros resultam em 0 posts para aquele tipo
- [x] Página carrega sem erros em mobile e desktop