### PR TITLE
fix: always proxy PDF requests to resolve CORS in production

### DIFF
--- a/src/app/api/pdf-proxy/route.ts
+++ b/src/app/api/pdf-proxy/route.ts
@@ -17,14 +17,10 @@ export async function GET(request: Request) {
       });
     }
 
-    const arrayBuffer = await response.arrayBuffer();
-
-    return new NextResponse(arrayBuffer, {
+    return new NextResponse(response.body, {
       headers: {
         "Content-Type":
           response.headers.get("Content-Type") || "application/pdf",
-
-        // Libera o CORS para o seu frontend
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET",
         "Cache-Control": "public, max-age=3600",

--- a/src/app/boletim/[id]/BoletimContent.tsx
+++ b/src/app/boletim/[id]/BoletimContent.tsx
@@ -19,10 +19,7 @@ export const BoletimContent = ({
   const dateObj = boletim.date ? new Date(boletim.date) : null;
   const formattedDate = dateObj ? dateObj.toLocaleDateString("pt-BR") : "";
 
-  const isDev = process.env.NODE_ENV === "development";
-  const finalPdfUrl = isDev
-    ? `/api/pdf-proxy?url=${encodeURIComponent(boletim.link)}`
-    : boletim.link;
+  const finalPdfUrl = `/api/pdf-proxy?url=${encodeURIComponent(boletim.link)}`;
 
   const category = boletim.categoryCollection?.items?.[0];
   const categoryId = category?.sys?.id;
@@ -36,7 +33,7 @@ export const BoletimContent = ({
             title={boletim.title}
             description={boletim.description}
             formattedDate={formattedDate}
-            pdfUrl={boletim.link}
+            pdfUrl={finalPdfUrl}
             pdfFileName={pdfFileName}
           />
           <div className="mt-6 -mx-4 sm:mx-0">


### PR DESCRIPTION
## fix: redirecionar PDFs sempre pelo proxy para resolver CORS em produção

### Descrição

Os boletins não carregavam em produção porque o `pdfjs-dist` faz o fetch do PDF via `fetch` do navegador, que é bloqueado por CORS. Os servidores externos (ex: `gov.br`) não enviam `Access-Control-Allow-Origin`, impedindo o carregamento.

O `/api/pdf-proxy` já existia como workaround apenas em desenvolvimento. Este fix o habilita também em produção — todas as requisições de PDF passam a usar o proxy de mesma origem, que busca o PDF server-side (sem restrições de CORS) e o serve com os headers corretos.

### Arquivos alterados

| Arquivo | Status |
|---|---|
| `src/app/boletim/[id]/BoletimContent.tsx` | Modificado |
| `src/app/api/pdf-proxy/route.ts` | Modificado |

### Causa raiz

`BoletimContent.tsx:22-25` continha:

```ts
const isDev = process.env.NODE_ENV === "development";
const finalPdfUrl = isDev
  ? `/api/pdf-proxy?url=${encodeURIComponent(boletim.link)}`
  : boletim.link; // ← produção: URL direta, bloqueada por CORS