### PR TITLE
Fix/macrothemes order

### DIFF
--- a/src/components/ExploreFilters/ExploreFilters.test.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.test.tsx
@@ -29,7 +29,9 @@ describe("ExploreFilters", () => {
       />,
     );
 
-    const trigger = screen.getByRole("button", { name: "Veja por temas" });
+    const [trigger] = screen
+      .getAllByRole("button", { name: "Veja por temas" })
+      .filter((btn) => btn.hasAttribute("aria-controls"));
     const themeList = document.getElementById(
       trigger.getAttribute("aria-controls") ?? "",
     );

--- a/src/components/ExploreFilters/ExploreFilters.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.tsx
@@ -6,8 +6,12 @@ import { Checkbox } from "../ui/checkbox";
 import { SearchBar } from "../SearchBar/SearchBar";
 import { CatalogTextFilter } from "../CatalogTextFilter/CatalogTextFilter";
 import { Button } from "../ui/button";
-import { MACROTHEME_ICON_BY_ID } from "@/features/macrothemes/constants";
+import {
+  MACROTHEME_ICON_BY_ID,
+  THEMES_NAVIGATION_ORDER,
+} from "@/features/macrothemes/constants";
 import { sortingTypes } from "@/utils/constants";
+import { sortContentByDesiredOrder } from "@/utils/functions";
 import { normalizeKey } from "@/utils/functions";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { useCallback, useId, useMemo, useState } from "react";
@@ -123,11 +127,11 @@ function SeeThemesModal({
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-lg shadow-lg w-full max-w-[393px] max-h-[80vh] overflow-hidden flex flex-col"
+        className="bg-white rounded-lg shadow-lg w-full max-w-[393px] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex flex-col gap-6 p-6">
-          <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-6 p-6 flex-1 overflow-hidden">
+          <div className="flex items-center justify-between flex-shrink-0">
             <h2 className="text-[24px] font-semibold leading-[36px] tracking-[-0.0075em] text-[#292829]">
               Veja por temas
             </h2>
@@ -140,57 +144,71 @@ function SeeThemesModal({
             </button>
           </div>
 
-          <div className="flex flex-col gap-2 overflow-y-auto flex-1">
-            {themes.map((theme) => {
-              const iconKey = normalizeKey(theme.name);
-              const isChecked = selectedCategories.includes(theme.sys.id);
+          <div className="flex flex-col gap-4 overflow-y-auto flex-1">
+            {sortContentByDesiredOrder(themes, THEMES_NAVIGATION_ORDER).map(
+              (theme) => {
+                const iconKey = normalizeKey(theme.name);
+                const isChecked = selectedCategories.includes(theme.sys.id);
 
-              return (
-                <div
-                  key={theme.sys.id}
-                  className="flex flex-row h-8 bg-[#F8F7F8] border border-[#EFEFEF] rounded-lg cursor-pointer hover:bg-[#F0EFEF] transition-colors flex-shrink-0"
-                  onClick={() => onToggleCategory(theme.sys.id)}
-                >
-                  <div className="flex items-center justify-center h-full w-8 rounded-l-lg hover:bg-[#DDEADF] transition-colors">
-                    <Checkbox
-                      checked={isChecked}
-                      onCheckedChange={() => onToggleCategory(theme.sys.id)}
-                      className="w-4 h-4 border-[#018F39] data-[state=checked]:bg-[#018F39] flex-shrink-0 rounded"
-                      onClick={(e) => e.stopPropagation()}
-                    />
+                return (
+                  <div
+                    key={theme.sys.id}
+                    className="flex flex-row h-10 bg-[#F8F7F8] border border-[#EFEFEF] rounded-lg cursor-pointer hover:bg-[#F0EFEF] transition-colors flex-shrink-0"
+                    onClick={() => onToggleCategory(theme.sys.id)}
+                  >
+                    <div className="flex items-center justify-center h-full w-10 rounded-l-lg hover:bg-[#DDEADF] transition-colors">
+                      <Checkbox
+                        checked={isChecked}
+                        onCheckedChange={() => onToggleCategory(theme.sys.id)}
+                        className="w-5 h-5 border-[#018F39] data-[state=checked]:bg-[#018F39] flex-shrink-0 rounded"
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    </div>
+
+                    <div className="w-px h-full bg-[#EFEFEF]" />
+
+                    <div className="flex items-center gap-2 flex-1 h-full px-3 rounded-r-lg hover:bg-[#DDEADF] transition-colors">
+                      <Icon
+                        id={MACROTHEME_ICON_BY_ID[iconKey] || "list"}
+                        size={16}
+                        style={{ color: theme.color || "#999999" }}
+                      />
+
+                      <span className="flex-1 text-base font-normal text-[#292829] truncate">
+                        {theme.name}
+                      </span>
+
+                      <Icon
+                        className="text-[#999999] flex-shrink-0 rotate-270"
+                        id="expand"
+                        size={12}
+                      />
+                    </div>
                   </div>
-
-                  <div className="w-px h-full bg-[#EFEFEF]" />
-
-                  <div className="flex items-center gap-2 flex-1 h-full px-2 rounded-r-lg hover:bg-[#DDEADF] transition-colors">
-                    <Icon
-                      id={MACROTHEME_ICON_BY_ID[iconKey] || "list"}
-                      size={16}
-                      style={{ color: theme.color || "#999999" }}
-                    />
-
-                    <span className="flex-1 text-sm font-normal text-[#292829] truncate">
-                      {theme.name}
-                    </span>
-
-                    <Icon
-                      className="text-[#999999] flex-shrink-0 rotate-270"
-                      id="expand"
-                      size={12}
-                    />
-                  </div>
-                </div>
-              );
-            })}
+                );
+              },
+            )}
+            <button
+              className="flex items-center justify-center w-full h-10 px-4 py-2 rounded-md text-[#018F39] font-medium text-sm"
+              onClick={() => {
+                themes.forEach((t) => {
+                  if (!selectedCategories.includes(t.sys.id)) {
+                    onToggleCategory(t.sys.id);
+                  }
+                });
+              }}
+            >
+              Selecionar todos
+            </button>
           </div>
 
-          <div className="flex flex-row gap-3">
+          <div className="flex flex-row gap-3 flex-shrink-0">
             <Button
               variant="secondary"
               className="flex-1 h-10 bg-white border border-[#EFEFEF] rounded-md text-[#E5333F] hover:bg-grey-100"
               onClick={onClose}
             >
-              Cancelar
+              Voltar
             </Button>
             <Button
               className="flex-1 h-10 bg-[#018F39] hover:bg-[#018F39]/90 text-[#F8F7F8] rounded-md"
@@ -429,30 +447,49 @@ export function ExploreFilters({
           <div
             id={mobileThemesId}
             className={cn(
-              "flex flex-wrap gap-x-4 gap-y-2 w-full mt-4",
+              "flex flex-wrap gap-x-6 gap-y-4 w-full mt-4",
               mobileCatalogLayout && !mobileThemesOpen && "max-lg:hidden",
             )}
           >
-            {themes.map((theme) => {
-              const iconKey = normalizeKey(theme.name);
-              const themeValue =
-                categoryValues?.[theme.sys.id] ??
-                (categoryValue === "theme-id"
-                  ? (theme as MacroTheme & { id: string }).id
-                  : theme.sys.id);
+            {sortContentByDesiredOrder(themes, THEMES_NAVIGATION_ORDER).map(
+              (theme) => {
+                const iconKey = normalizeKey(theme.name);
+                const themeValue =
+                  categoryValues?.[theme.sys.id] ??
+                  (categoryValue === "theme-id"
+                    ? (theme as MacroTheme & { id: string }).id
+                    : theme.sys.id);
 
-              return (
-                <ThemeFilterCard
-                  key={themeValue}
-                  iconId={MACROTHEME_ICON_BY_ID[iconKey] || "list"}
-                  color={theme.color || "#999999"}
-                  name={theme.name}
-                  href={`/macrothemes/${theme.id.replace(/_/g, "-")}`}
-                  checked={selectedCategories.includes(themeValue)}
-                  onCheckedChange={() => toggleCategory(themeValue)}
-                />
-              );
-            })}
+                return (
+                  <ThemeFilterCard
+                    key={themeValue}
+                    iconId={MACROTHEME_ICON_BY_ID[iconKey] || "list"}
+                    color={theme.color || "#999999"}
+                    name={theme.name}
+                    href={`/macrothemes/${theme.id.replace(/_/g, "-")}`}
+                    checked={selectedCategories.includes(themeValue)}
+                    onCheckedChange={() => toggleCategory(themeValue)}
+                  />
+                );
+              },
+            )}
+            <button
+              className="flex items-center justify-center w-[145px] h-8 px-4 py-2 rounded-md text-[#018F39] font-medium text-sm"
+              onClick={() => {
+                themes.forEach((t) => {
+                  const themeValue =
+                    categoryValues?.[t.sys.id] ??
+                    (categoryValue === "theme-id"
+                      ? (t as MacroTheme & { id: string }).id
+                      : t.sys.id);
+                  if (!selectedCategories.includes(themeValue)) {
+                    toggleCategory(themeValue);
+                  }
+                });
+              }}
+            >
+              Selecionar todos
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/ExploreFilters/ExploreFilters.tsx
+++ b/src/components/ExploreFilters/ExploreFilters.tsx
@@ -112,12 +112,14 @@ function SeeThemesModal({
   themes,
   selectedCategories,
   onToggleCategory,
+  onSelectAll,
   onClose,
   onApply,
 }: {
   themes: Pick<MacroTheme, "id" | "name" | "color" | "sys">[];
   selectedCategories: string[];
   onToggleCategory: (themeId: string) => void;
+  onSelectAll: () => void;
   onClose: () => void;
   onApply: () => void;
 }) {
@@ -190,13 +192,7 @@ function SeeThemesModal({
             )}
             <button
               className="flex items-center justify-center w-full h-10 px-4 py-2 rounded-md text-[#018F39] font-medium text-sm"
-              onClick={() => {
-                themes.forEach((t) => {
-                  if (!selectedCategories.includes(t.sys.id)) {
-                    onToggleCategory(t.sys.id);
-                  }
-                });
-              }}
+              onClick={onSelectAll}
             >
               Selecionar todos
             </button>
@@ -275,6 +271,10 @@ export function ExploreFilters({
         ? prev.filter((id) => id !== themeId)
         : [...prev, themeId],
     );
+  };
+
+  const selectAllPending = () => {
+    setPendingCategories(themes.map((t) => t.sys.id));
   };
 
   const updateUrl = useCallback(
@@ -476,16 +476,22 @@ export function ExploreFilters({
             <button
               className="flex items-center justify-center w-[145px] h-8 px-4 py-2 rounded-md text-[#018F39] font-medium text-sm"
               onClick={() => {
-                themes.forEach((t) => {
-                  const themeValue =
-                    categoryValues?.[t.sys.id] ??
-                    (categoryValue === "theme-id"
-                      ? (t as MacroTheme & { id: string }).id
-                      : t.sys.id);
-                  if (!selectedCategories.includes(themeValue)) {
-                    toggleCategory(themeValue);
-                  }
-                });
+                const missing = themes
+                  .map(
+                    (t) =>
+                      categoryValues?.[t.sys.id] ??
+                      (categoryValue === "theme-id"
+                        ? (t as MacroTheme & { id: string }).id
+                        : t.sys.id),
+                  )
+                  .filter((v) => !selectedCategories.includes(v));
+
+                if (missing.length > 0) {
+                  updateUrl({
+                    category: [...selectedCategories, ...missing].join(","),
+                    page: "1",
+                  });
+                }
               }}
             >
               Selecionar todos
@@ -559,6 +565,7 @@ export function ExploreFilters({
           themes={themes}
           selectedCategories={pendingCategories}
           onToggleCategory={togglePendingCategory}
+          onSelectAll={selectAllPending}
           onClose={closeSeeThemesModal}
           onApply={applySeeThemesModal}
         />

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@/components/Icon/Icon";
-import { channels } from "@/utils/constants";
+import { channels, THEMES_NAVIGATION_ORDER } from "@/utils/constants";
 import { sortContentByDesiredOrder } from "@/utils/functions";
 import { ISection } from "@/utils/interfaces";
 
@@ -12,9 +12,12 @@ const Footer = ({ content }: { content: ISection[] }) => {
     "projects",
   ]).filter((item) => item.appears);
 
-  const macroThemes = content
-    .filter((item) => !item.appears && item.path?.startsWith("/macrothemes/"))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const macroThemes = sortContentByDesiredOrder(
+    content.filter(
+      (item) => !item.appears && item.path?.startsWith("/macrothemes/"),
+    ),
+    THEMES_NAVIGATION_ORDER,
+  );
 
   const splitColumns = <T,>(array: T[], itemsPerColumn: number) => {
     const columns = [];

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -39,12 +39,6 @@ const Header = ({ content }: { content: ISection[] }) => {
                         {item.name}
                       </NavigationMenuTrigger>
                       <NavigationMenuContent className="bg-white shadow-md p-2 rounded-md w-auto flex flex-col mt-15">
-                        <NavigationMenuLink
-                          href="/explore"
-                          className="flex flex-row items-center py-[6px] px-3 w-full whitespace-nowrap gap-2 rounded"
-                        >
-                          Ver todos
-                        </NavigationMenuLink>
                         {sortContentByDesiredOrder(
                           item.childrenCollection.items,
                           THEMES_NAVIGATION_ORDER,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,7 +10,8 @@ import {
 } from "@/components/ui/navigation-menu";
 import Link from "next/link";
 import { Icon } from "../Icon/Icon";
-import { macroThemes } from "@/utils/constants";
+import { macroThemes, THEMES_NAVIGATION_ORDER } from "@/utils/constants";
+import { sortContentByDesiredOrder } from "@/utils/functions";
 import { SearchBar } from "@/components/SearchBar/SearchBar";
 
 const Header = ({ content }: { content: ISection[] }) => {
@@ -38,7 +39,16 @@ const Header = ({ content }: { content: ISection[] }) => {
                         {item.name}
                       </NavigationMenuTrigger>
                       <NavigationMenuContent className="bg-white shadow-md p-2 rounded-md w-auto flex flex-col mt-15">
-                        {item.childrenCollection.items.map((child) => (
+                        <NavigationMenuLink
+                          href="/explore"
+                          className="flex flex-row items-center py-[6px] px-3 w-full whitespace-nowrap gap-2 rounded"
+                        >
+                          Ver todos
+                        </NavigationMenuLink>
+                        {sortContentByDesiredOrder(
+                          item.childrenCollection.items,
+                          THEMES_NAVIGATION_ORDER,
+                        ).map((child) => (
                           <NavigationMenuLink
                             key={child.id}
                             href={child.path}

--- a/src/components/Header/Modal/HeaderModal.tsx
+++ b/src/components/Header/Modal/HeaderModal.tsx
@@ -65,11 +65,6 @@ const HeaderModal = ({ content }: { content: ISection[] }) => {
                       {item.name}
                     </AccordionTrigger>
                     <AccordionContent className="py-2 px-2">
-                      <Link href="/explore" onClick={() => setOpen(false)}>
-                        <div className="flex items-center gap-2 py-[6px] px-2 h-[44px] hover:bg-green-neutro cursor-pointer">
-                          <span className="whitespace-nowrap">Ver todos</span>
-                        </div>
-                      </Link>
                       {sortContentByDesiredOrder(
                         item.childrenCollection.items,
                         THEMES_NAVIGATION_ORDER,

--- a/src/components/Header/Modal/HeaderModal.tsx
+++ b/src/components/Header/Modal/HeaderModal.tsx
@@ -11,11 +11,11 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { macroThemes } from "@/utils/constants";
+import { macroThemes, THEMES_NAVIGATION_ORDER } from "@/utils/constants";
 import { Icon } from "@/components/Icon/Icon";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useState } from "react";
-import { isHrefActive } from "@/utils/functions";
+import { isHrefActive, sortContentByDesiredOrder } from "@/utils/functions";
 import { cn } from "@/lib/utils";
 import { SearchBar } from "@/components/SearchBar/SearchBar";
 
@@ -65,7 +65,15 @@ const HeaderModal = ({ content }: { content: ISection[] }) => {
                       {item.name}
                     </AccordionTrigger>
                     <AccordionContent className="py-2 px-2">
-                      {item.childrenCollection.items.map((child, i) => {
+                      <Link href="/explore" onClick={() => setOpen(false)}>
+                        <div className="flex items-center gap-2 py-[6px] px-2 h-[44px] hover:bg-green-neutro cursor-pointer">
+                          <span className="whitespace-nowrap">Ver todos</span>
+                        </div>
+                      </Link>
+                      {sortContentByDesiredOrder(
+                        item.childrenCollection.items,
+                        THEMES_NAVIGATION_ORDER,
+                      ).map((child, i) => {
                         const isActive = isHrefActive(
                           pathname,
                           category,

--- a/src/features/macrothemes/constants.ts
+++ b/src/features/macrothemes/constants.ts
@@ -11,6 +11,7 @@ export const MACROTHEME_ICON_BY_ID: { [key: string]: string } = {
 };
 
 export const THEMES_NAVIGATION_ORDER = [
+  "ver_todos",
   "demografia",
   "educacao",
   "economia_e_renda",

--- a/src/features/macrothemes/constants.ts
+++ b/src/features/macrothemes/constants.ts
@@ -11,14 +11,14 @@ export const MACROTHEME_ICON_BY_ID: { [key: string]: string } = {
 };
 
 export const THEMES_NAVIGATION_ORDER = [
-  "saude",
-  "educacao",
-  "desenvolvimento_social",
-  "economia_e_renda",
   "demografia",
+  "educacao",
+  "economia_e_renda",
+  "desenvolvimento_social",
+  "saude",
   "infraestrutura_e_saneamento",
-  "meio_ambiente",
   "seguranca_hidrica",
+  "meio_ambiente",
   "instrumentos_sudene",
 ];
 


### PR DESCRIPTION
## PR: Fix macrotheme navigation order and "Ver todos" link

**Changes**

**1. Macrotheme order (`src/features/macrothemes/constants.ts`)**
- Added `"ver_todos"` as first item in `THEMES_NAVIGATION_ORDER` so the CMS item is sorted to the top naturally, without any filter or manual link in the components
- Order: Ver todos → Demografia → Educação → Economia e Renda → Desenvolvimento Social → Saúde → Infraestrutura e Saneamento → Segurança Hídrica → Meio Ambiente → Instrumentos Sudene

**2. Apply consistent ordering everywhere**
- `Header.tsx` / `HeaderModal.tsx` — macrothemes dropdown children sorted by `THEMES_NAVIGATION_ORDER`
- `ExploreFilters.tsx` — theme lists (modal + desktop grid) sorted by `THEMES_NAVIGATION_ORDER`
- `Footer.tsx` — changed from `localeCompare` to `sortContentByDesiredOrder` with `THEMES_NAVIGATION_ORDER`
- `DataSection.tsx` — already used the constant, no change needed

**3. Filter modal — "Selecionar todos"**
- `ExploreFilters.tsx` — added "Selecionar todos" button at end of theme list (before Cancelar/Aplicar)
- Removed `max-h-[80vh]` so modal fits all content without scrolling
- Set `gap-4` (16px) between items per design
- Increased item height to `h-10` (40px) with `w-5 h-5` checkboxes per design spec

**4. Desktop filters — "Selecionar todos"**
- `ExploreFilters.tsx` — added 145px × 32px button at end of the flex-wrap theme grid
- Fixed gap to `gap-x-6` (24px) / `gap-y-4` (16px) per design

**5. Test fix (`ExploreFilters.test.tsx`)**
- Updated to use `getAllByRole` + `aria-controls` filter since there are now two "Veja por temas" buttons