### PR TITLE
refactor: improve related content ranking and panel description CTA

### DIFF
--- a/src/app/data-panel/[id]/page.tsx
+++ b/src/app/data-panel/[id]/page.tsx
@@ -74,6 +74,7 @@ export default async function DataPanel({
     descriptionTitle: panel.descriptionTitle,
     descriptionText: getPanelDescriptionText(panel),
   });
+  const catalogHref = getCatalogHref(panel.macroTheme);
 
   return (
     <HubTemplate>
@@ -81,6 +82,7 @@ export default async function DataPanel({
         <div className="flex justify-center w-full items-center overflow-hidden">
           <PowerBIContainer panel={panel} pageName={pageName} />
         </div>
+        {catalogHref && <CatalogLink href={catalogHref} />}
       </div>
 
       <PanelDescriptionSection panel={panel} />
@@ -125,6 +127,24 @@ const MacroThemeLink = ({ href }: { href: string }) => (
     <Icon className="size-2 rotate-270" id="expand" size={9} />
   </Link>
 );
+
+const CatalogLink = ({ href }: { href: string }) => (
+  <Link
+    className="mt-4 inline-flex h-10 w-full items-center justify-center gap-3 rounded-md bg-green-800 px-5 text-sm font-medium leading-6 text-white transition hover:bg-green-900"
+    href={href}
+  >
+    Acessar o catálogo de dados
+    <Icon className="size-4" id="database" size={16} />
+  </Link>
+);
+
+const getCatalogHref = (macroTheme: string): string | null => {
+  const slug = MACROTHEME_ROUTE_BY_NAME[
+    macroTheme as keyof typeof MACROTHEME_ROUTE_BY_NAME
+  ];
+
+  return slug ? `/catalog?category=${slug}` : null;
+};
 
 const getMacroThemeHref = (macroTheme: string): string | null => {
   const slug = MACROTHEME_ROUTE_BY_NAME[

--- a/src/app/data-panel/[id]/page.tsx
+++ b/src/app/data-panel/[id]/page.tsx
@@ -11,6 +11,9 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { documentToPlainTextString } from "@contentful/rich-text-plain-text-renderer";
 import { getSearchIndex } from "@/features/search/contentful";
 import { getRelatedPanelItems } from "@/features/search/relatedPanels";
+import Link from "next/link";
+import { Icon } from "@/components/Icon/Icon";
+import { MACROTHEME_ROUTE_BY_NAME } from "@/features/macrothemes/constants";
 
 interface IDataPanelContent {
   panelsCollection: { items: ReportData[] };
@@ -80,27 +83,56 @@ export default async function DataPanel({
         </div>
       </div>
 
-      {(panel.descriptionTitle || panel.description?.json) && (
-        <section className="w-full bg-[#EFEFEF] py-10">
-          <div className="w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-20 flex flex-col gap-6">
-            {panel.descriptionTitle && (
-              <h2 className="text-[30px] font-semibold leading-[36px] text-[#292829]">
-                {panel.descriptionTitle}
-              </h2>
-            )}
-            {panel.description?.json && (
-              <div className="text-base leading-[150%] text-[#292829] whitespace-pre-line">
-                {documentToReactComponents(panel.description.json)}
-              </div>
-            )}
-          </div>
-        </section>
-      )}
+      <PanelDescriptionSection panel={panel} />
 
       <RelatedPanelsSection items={relatedPanels} />
     </HubTemplate>
   );
 }
+
+const PanelDescriptionSection = ({ panel }: { panel: ReportData }) => {
+  if (!panel.descriptionTitle && !panel.description?.json) return null;
+
+  const macroThemeHref = getMacroThemeHref(panel.macroTheme);
+
+  return (
+    <section className="w-full bg-[#EFEFEF] py-10">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-4 sm:px-6 lg:px-20">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          {panel.descriptionTitle && (
+            <h2 className="text-[30px] font-semibold leading-[36px] text-[#292829]">
+              {panel.descriptionTitle}
+            </h2>
+          )}
+          {macroThemeHref && <MacroThemeLink href={macroThemeHref} />}
+        </div>
+        {panel.description?.json && (
+          <div className="text-base leading-[150%] text-[#292829] [&>p+p]:mt-4">
+            {documentToReactComponents(panel.description.json)}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+const MacroThemeLink = ({ href }: { href: string }) => (
+  <Link
+    className="ml-auto inline-flex h-10 shrink-0 items-center justify-center gap-3 rounded-md bg-white px-5 text-sm font-medium leading-6 text-green-900 transition hover:bg-green-neutro"
+    href={href}
+  >
+    Ver mais sobre o tema
+    <Icon className="size-2 rotate-270" id="expand" size={9} />
+  </Link>
+);
+
+const getMacroThemeHref = (macroTheme: string): string | null => {
+  const slug = MACROTHEME_ROUTE_BY_NAME[
+    macroTheme as keyof typeof MACROTHEME_ROUTE_BY_NAME
+  ];
+
+  return slug ? `/macrothemes/${slug}` : null;
+};
 
 const getPanelDescriptionText = (panel: ReportData): string => {
   if (!panel.description?.json) return "";

--- a/src/features/search/relatedPanels.test.ts
+++ b/src/features/search/relatedPanels.test.ts
@@ -11,14 +11,18 @@ const baseItem = {
 } satisfies Partial<SearchIndexItem>;
 
 describe("related panel helpers", () => {
-  it("returns related panels by theme and text score", () => {
+  it("favors related content in different themes", () => {
     const results = getRelatedPanelItems(buildSearchItems(), {
       title: "Produto Interno Bruto",
       macroTheme: "Economia",
       descriptionTitle: "PIB municipal",
     });
 
-    expect(results.map((item) => item.id)).toEqual(["panel:2", "panel:3"]);
+    expect(results.map((item) => item.id)).toEqual([
+      "post:story",
+      "post:newsletter",
+      "panel:2",
+    ]);
   });
 
   it("excludes the current panel and respects limit", () => {
@@ -37,9 +41,24 @@ describe("related panel helpers", () => {
       title: "Painel Produto Interno Bruto",
       href: "/data-panel/Produto%20Interno%20Bruto",
       macroTheme: "Economia",
+      descriptionTitle: "PIB municipal",
     });
 
-    expect(results.map((item) => item.id)).toEqual(["panel:2", "panel:3"]);
+    expect(results.map((item) => item.id)).toEqual([
+      "post:story",
+      "post:newsletter",
+      "panel:2",
+    ]);
+  });
+
+  it("does not recommend unrelated content from different themes", () => {
+    const results = getRelatedPanelItems(buildSearchItems(), {
+      title: "Produto Interno Bruto",
+      macroTheme: "Economia",
+      descriptionTitle: "PIB municipal",
+    });
+
+    expect(results.map((item) => item.id)).not.toContain("post:unrelated");
   });
 });
 
@@ -77,11 +96,34 @@ const buildSearchItems = (): SearchIndexItem[] => [
   },
   {
     ...baseItem,
-    id: "post:1",
+    id: "post:newsletter",
     source: "post",
     type: "newsletter",
-    title: "Boletim economia",
+    title: "Boletim sobre PIB municipal",
     href: "/posts/boletim-economia",
-    text: "economia pib",
+    themes: ["Mercado de Trabalho"],
+    tags: ["PIB"],
+    text: "boletim mercado trabalho pib municipal",
+  },
+  {
+    ...baseItem,
+    id: "post:story",
+    source: "post",
+    type: "data-story",
+    title: "Datastory do PIB municipal",
+    href: "/data-stories/story-id",
+    themes: ["Território"],
+    tags: ["PIB"],
+    text: "datastory territorio produto pib municipal renda",
+  },
+  {
+    ...baseItem,
+    id: "post:unrelated",
+    source: "post",
+    type: "newsletter",
+    title: "Boletim climático",
+    href: "/posts/boletim-climatico",
+    themes: ["Meio Ambiente"],
+    text: "clima chuva semiárido",
   },
 ];

--- a/src/features/search/relatedPanels.ts
+++ b/src/features/search/relatedPanels.ts
@@ -4,16 +4,44 @@ import type { SearchIndexItem, SearchResult } from "./types";
 const DEFAULT_RELATED_PANELS_LIMIT = 8;
 const RELATED_TOKEN_STOPWORDS = new Set([
   "a",
+  "acessar",
+  "ao",
+  "aos",
   "as",
+  "boletim",
+  "com",
+  "conteudo",
+  "da",
+  "das",
+  "dados",
+  "data",
+  "datastory",
   "de",
   "do",
   "dos",
   "e",
   "em",
+  "informacao",
+  "informacoes",
+  "na",
+  "nas",
+  "no",
+  "nos",
+  "nordeste",
   "o",
   "os",
   "para",
   "painel",
+  "por",
+  "relacionado",
+  "uma",
+  "um",
+]);
+
+const RELATED_CONTENT_TYPES = new Set<SearchIndexItem["type"]>([
+  "data-panel-detail",
+  "data-story",
+  "newsletter",
 ]);
 
 type RelatedPanelOptions = {
@@ -35,10 +63,15 @@ export const getRelatedPanelItems = (
 ): SearchResult[] => {
   const currentText = buildRelatedPanelText(currentPanel);
   const currentTokens = getRelatedPanelTokens(currentText);
+  const candidates = items.filter((item) =>
+    isRelatedPanelCandidate(item, currentPanel),
+  );
+  const tokenWeights = buildRelatedPanelTokenWeights(candidates);
 
-  return items
-    .filter((item) => isRelatedPanelCandidate(item, currentPanel))
-    .map((item) => scoreRelatedPanelItem(item, currentPanel, currentTokens))
+  return candidates
+    .map((item) =>
+      scoreRelatedPanelItem(item, currentPanel, currentTokens, tokenWeights),
+    )
     .filter((item): item is SearchResult => Boolean(item))
     .sort(compareRelatedPanelItems)
     .slice(0, limit);
@@ -47,7 +80,6 @@ export const getRelatedPanelItems = (
 const buildRelatedPanelText = (panel: RelatedPanelReference): string =>
   buildSearchText([
     panel.title,
-    panel.macroTheme,
     panel.descriptionTitle,
     panel.descriptionText,
   ]);
@@ -56,7 +88,7 @@ const isRelatedPanelCandidate = (
   item: SearchIndexItem,
   currentPanel: RelatedPanelReference,
 ): boolean => {
-  if (item.type !== "data-panel-detail") return false;
+  if (!RELATED_CONTENT_TYPES.has(item.type)) return false;
   if (currentPanel.href && item.href === currentPanel.href) return false;
 
   return (
@@ -68,12 +100,15 @@ const scoreRelatedPanelItem = (
   item: SearchIndexItem,
   currentPanel: RelatedPanelReference,
   currentTokens: Set<string>,
+  tokenWeights: Map<string, number>,
 ): SearchResult | null => {
+  const textScore = getRelatedPanelTextScore(item, currentTokens, tokenWeights);
+  if (textScore === 0) return null;
+
   const themeScore = getRelatedPanelThemeScore(item, currentPanel);
-  const textScore = getRelatedPanelTextScore(item, currentTokens);
   const score = themeScore + textScore;
 
-  return score > 0 ? { ...item, score } : null;
+  return { ...item, score };
 };
 
 const getRelatedPanelThemeScore = (
@@ -83,25 +118,59 @@ const getRelatedPanelThemeScore = (
   const currentTheme = normalizeSearchText(currentPanel.macroTheme);
 
   if (!currentTheme) return 0;
-  if (
-    item.themes.some((theme) => normalizeSearchText(theme) === currentTheme)
-  ) {
-    return 100;
-  }
+  if (item.themes.length === 0) return 0;
+  if (hasMatchingTheme(item, currentTheme)) return 0;
 
-  return 0;
+  return 16;
 };
+
+const hasMatchingTheme = (
+  item: SearchIndexItem,
+  currentTheme: string,
+): boolean =>
+  item.themes.some((theme) => normalizeSearchText(theme) === currentTheme);
 
 const getRelatedPanelTextScore = (
   item: SearchIndexItem,
   currentTokens: Set<string>,
+  tokenWeights: Map<string, number>,
 ): number => {
   const itemTokens = getRelatedPanelTokens(item.text);
   const sharedTokens = [...currentTokens].filter((token) =>
     itemTokens.has(token),
   );
 
-  return sharedTokens.length * 8;
+  return sharedTokens.reduce(
+    (score, token) => score + (tokenWeights.get(token) || 0),
+    0,
+  );
+};
+
+const buildRelatedPanelTokenWeights = (
+  items: SearchIndexItem[],
+): Map<string, number> => {
+  const tokenCounts = countRelatedPanelTokens(items);
+
+  return new Map(
+    [...tokenCounts.entries()].map(([token, count]) => [
+      token,
+      Math.round(12 + (items.length / count) * 8),
+    ]),
+  );
+};
+
+const countRelatedPanelTokens = (
+  items: SearchIndexItem[],
+): Map<string, number> => {
+  const tokenCounts = new Map<string, number>();
+
+  items.forEach((item) => {
+    getRelatedPanelTokens(item.text).forEach((token) => {
+      tokenCounts.set(token, (tokenCounts.get(token) || 0) + 1);
+    });
+  });
+
+  return tokenCounts;
 };
 
 const getRelatedPanelTokens = (text: string): Set<string> =>


### PR DESCRIPTION
# Description 

Updates related content recommendations to prioritize shared subjects across different macrothemes and include panels, datastories, and newsletters. Also adjusts the panel description section to match the Figma layout, keeping title/body content from Contentful and adding a macrotheme link button.