### PR TITLE
Refactor/align design

### DIFF
--- a/src/app/macrothemes/[slug]/page.tsx
+++ b/src/app/macrothemes/[slug]/page.tsx
@@ -134,7 +134,9 @@ export default async function MacroThemePage({
 
       <div className="w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-20 mt-12 pb-10 pt-0">
         {!!theme.articleTitle && (
-          <h2 className="text-2xl font-semibold">{theme.articleTitle}</h2>
+          <h2 className="text-xl lg:text-3xl font-semibold">
+            {theme.articleTitle}
+          </h2>
         )}
 
         {!!theme.article?.json && (

--- a/src/components/AboutBigCard/AboutBigCard.tsx
+++ b/src/components/AboutBigCard/AboutBigCard.tsx
@@ -6,25 +6,25 @@ const AboutBigCard = ({ content }: { content: IAbout }) => {
   const { details, thumb, id } = content;
 
   return (
-    <section className="flex items-center justify-center w-full">
-      <div className="flex flex-col items-left">
-        <h2 className="font-semibold text-3xl">{id}</h2>
-        <div className=" my-5">
-          {thumb && (
-            <Image
-              className="w-full float-none md:float-left h-full md:max-w-[450px] object-cover rounded-md aspect-[4/3] order-1 mb-4 mr-4"
-              src={thumb?.url || ""}
-              alt={"Sobre nós"}
-              width={600}
-              height={600}
-            />
-          )}
-          <div className="h-full text-gray-800 order-2 text-justify">
-            {documentToReactComponents(details.json)}
-          </div>
+    <div className="flex flex-col w-full gap-6">
+      <h2 className="text-[30px] font-semibold leading-[36px] tracking-[-0.0075em] text-[#292829]">
+        {id}
+      </h2>
+      <div className="flex flex-col lg:flex-row gap-6">
+        {thumb && (
+          <Image
+            className="w-full lg:w-[450px] h-[337px] object-cover rounded-md shrink-0"
+            src={thumb?.url || ""}
+            alt={"Sobre nós"}
+            width={450}
+            height={337}
+          />
+        )}
+        <div className="text-[16px] leading-[24px] text-[#292829] order-2 text-justify prose prose-lg max-w-none lg:flex-1">
+          {documentToReactComponents(details.json)}
         </div>
       </div>
-    </section>
+    </div>
   );
 };
 

--- a/src/components/AboutContent/AboutContent.tsx
+++ b/src/components/AboutContent/AboutContent.tsx
@@ -1,11 +1,6 @@
 "use client";
 
 import { ITab } from "@/utils/interfaces";
-import {
-  NavigationMenu,
-  NavigationMenuItem,
-  NavigationMenuList,
-} from "../ui/navigation-menu";
 import { ReactElement } from "react";
 import { sortContentByDesiredOrder } from "@/utils/functions";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -38,27 +33,29 @@ export const AboutContent = ({
 
   return (
     <>
-      <div className="w-full border-b border-grey-400">
-        <section className="flex justify-center w-full h-[60px] max-w-[1440px] mx-auto">
-          <NavigationMenu className="flex flex-row justify-start w-full max-w-[1440px] mx-6 lg:mx-20 overflow-x-auto overflow-y-hidden">
-            <NavigationMenuList className="gap-4 min-w-max">
-              {orderedContent.map((tab, idx) => (
-                <NavigationMenuItem key={idx}>
-                  <button
-                    onClick={() => handleTabClick(tab.path)}
-                    className={`cursor-pointer text-md text-center pt-[20px] pb-[18px] px-[12px] rounded-none box-border ${
-                      currentTab === tab.path
-                        ? "text-green-800 border-b-10 border-b-green-800"
-                        : "text-muted-foreground"
-                    }`}
-                  >
-                    {tab.name}
-                  </button>
-                </NavigationMenuItem>
-              ))}
-            </NavigationMenuList>
-          </NavigationMenu>
-        </section>
+      <div className="w-full bg-white border-b border-[#BEBBBD]">
+        <div
+          role="tablist"
+          className="flex flex-row items-end gap-4 max-w-[1440px] mx-auto lg:px-20 pt-2 overflow-x-auto scrollbar-hide"
+          style={{ height: "60px" }}
+        >
+          {orderedContent.map((tab, idx) => (
+            <button
+              key={idx}
+              role="tab"
+              aria-selected={currentTab === tab.path}
+              onClick={() => handleTabClick(tab.path)}
+              style={{ padding: "16px 12px", height: "52px" }}
+              className={`flex items-center justify-center font-medium text-[14px] leading-5 transition-colors border-b-2 outline-none focus-visible:ring-2 focus-visible:ring-[#018F39] ${
+                currentTab === tab.path
+                  ? "border-[#018F39] text-[#018F39]"
+                  : "border-transparent text-[#7E797B] hover:text-[#292829] hover:border-gray-300"
+              }`}
+            >
+              {tab.name}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="max-w-[1440px]">{tabs[currentTab]}</div>
     </>

--- a/src/components/ContentPost/ContentPost.tsx
+++ b/src/components/ContentPost/ContentPost.tsx
@@ -42,7 +42,7 @@ const ContentPost = ({ content }: { content: IPublication }) => {
         <div className="py-3 px-4 flex gap-4 justify-between h-full items-center box-border bg-[#F8F7F8]">
           <span className="sr-only">{title}</span>
           <p className="line-clamp-2 text-sm font-medium leading-5 tracking-[-0.03em] text-[#292829]">
-            {type === "data-panel" ? "Acessar Painel" : title}
+            {type === "data-panel" ? "Acessar" : title}
           </p>
           <Icon
             className="md:flex rotate-270 size-2 min-w-2"

--- a/src/components/HistorySection/HistorySection.tsx
+++ b/src/components/HistorySection/HistorySection.tsx
@@ -4,14 +4,18 @@ import { IAbout } from "@/utils/interfaces";
 
 const HistorySection = ({ content }: { content: IAbout }) => {
   return (
-    <section className="flex justify-center w-full px-6 py-9 lg:px-20">
-      <div className="flex flex-col items-left w-full max-w-[1440px]">
+    <section className="flex justify-center w-full px-6 lg:px-20 py-6">
+      <div className="flex flex-col items-left w-full max-w-[1440px] gap-12">
         <AboutBigCard content={content} />
-        <h2 className="text-green-900 text-2xl font-semibold">Galeria</h2>
-        <GalleryCarousel
-          album={content.albumCollection.items}
-          length={"basis-1/1 md:basis-1/2 lg:basis-1/3 xl:basis-1/4"}
-        />
+        <div className="flex flex-col gap-6">
+          <h3 className="text-[24px] font-semibold leading-[32px] tracking-[-0.006em] text-[#085F2D]">
+            Galeria
+          </h3>
+          <GalleryCarousel
+            album={content.albumCollection.items}
+            length={"basis-1/1 md:basis-1/2 lg:basis-1/3 xl:basis-1/4"}
+          />
+        </div>
       </div>
     </section>
   );

--- a/src/components/ValuesSection/ValuesSection.tsx
+++ b/src/components/ValuesSection/ValuesSection.tsx
@@ -6,18 +6,22 @@ const ValuesSection = ({ content }: { content: IValues[] }) => {
   const { title, thumb, details } = content[0];
 
   return (
-    <section className="flex items-center flex-col w-full px-6 py-9 lg:px-[80px] lg:py-[32px]">
-      <div className="flex flex-col w-full lg:max-w-[1440px] h-fit gap-[24px]">
-        <h1 className="text-[24px] lg:text-[30px] font-bold">{title}</h1>
-        <div className="">
-          <Image
-            className="w-full float-none md:float-left h-full md:max-w-[300px] object-cover rounded-md aspect-[16/9] order-1 mb-4 mr-4"
-            src={thumb?.url || ""}
-            alt={"Sobre nós"}
-            width={1200}
-            height={800}
-          />
-          <div className="h-full text-gray-800 order-2 text-justify">
+    <section className="flex items-center flex-col w-full px-6 lg:px-20 py-6">
+      <div className="flex flex-col w-full max-w-[1280px] gap-6">
+        <h1 className="text-[30px] font-semibold leading-[36px] tracking-[-0.0075em] text-[#292829] pb-2">
+          {title}
+        </h1>
+        <div className="flex flex-col lg:flex-row items-center gap-6">
+          {thumb?.url && (
+            <Image
+              className="w-full lg:w-[274px] h-[248px] object-cover rounded-lg shrink-0"
+              src={thumb.url}
+              alt={"Sobre nós"}
+              width={274}
+              height={248}
+            />
+          )}
+          <div className="prose max-w-none lg:flex-1 [&>p]:text-[16px] [&>p]:font-normal [&>p]:leading-[24px] [&>p]:text-[#292829] [&_*]:text-[#292829]">
             {documentToReactComponents(details.json)}
           </div>
         </div>


### PR DESCRIPTION
## Description

Updated about page components to match Figma design specs.

## Changes
- AboutContent: Replaced shadcn NavigationMenu with custom tabs following MacroThemeTabs design (border-bottom, 60px height, 52px tab items, active/inactive states)
- AboutBigCard: Added rich text prose styling, updated to Frame 65/45 specs (h2 30px/600, paragraph 16px/400 leading-24, gap-6 between elements)
- ValuesSection: Added prose styling, updated title to h3 style (24px/600 leading-32 tracking-[-0.006em] color-#085F2D), image to 274x248px, padding to py-12 (48px)
- HistorySection: Added gap-12 (48px) between AboutBigCard and gallery, updated "Galeria" h3 styling to match Figma (24px/600 leading-32 tracking-[-0.006em] color-#085F2D)
- PreviewContent & macrothemes page: Unified article title and preview section title sizing (text-xl lg:text-3xl)
- ValuesSection: Fixed empty src warning by conditionally rendering Image when thumb.url exists