### PR TITLE
Fix/pre release fixes

### DIFF
--- a/src/app/catalog/[id]/page.tsx
+++ b/src/app/catalog/[id]/page.tsx
@@ -59,7 +59,7 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
       <main className="w-full max-w-[1120px] mx-auto px-6 py-12 lg:px-20">
         <nav className="mb-8 text-sm text-grey-600">
           <Link href="/catalog" className="font-semibold text-[#018F39]">
-            Catalogo
+            Catálogo
           </Link>
           <span className="mx-2">/</span>
           <span>{record.id}</span>
@@ -83,7 +83,7 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
           <dl className="grid gap-4 rounded-lg bg-grey-100 p-5 sm:grid-cols-2 lg:grid-cols-4">
             <div>
               <dt className="text-xs font-semibold uppercase text-grey-600">
-                Publicacao
+                Publicação
               </dt>
               <dd className="mt-1 text-sm text-[#292829]">{formattedDate}</dd>
             </div>
@@ -95,13 +95,13 @@ export default async function DatasetPage({ params }: DatasetPageProps) {
             </div>
             <div>
               <dt className="text-xs font-semibold uppercase text-grey-600">
-                Licenca
+                Licença
               </dt>
               <dd className="mt-1 text-sm text-[#292829]">{record.license}</dd>
             </div>
             <div>
               <dt className="text-xs font-semibold uppercase text-grey-600">
-                Versao
+                Versão
               </dt>
               <dd className="mt-1 text-sm text-[#292829]">{record.version}</dd>
             </div>

--- a/src/app/data-panel/[id]/page.tsx
+++ b/src/app/data-panel/[id]/page.tsx
@@ -125,7 +125,7 @@ const MacroThemeLink = ({ href }: { href: string }) => (
     href={href}
   >
     Ver mais sobre o tema
-    <Icon className="size-2 rotate-270" id="expand" size={9} />
+    <Icon className="size-2" id="expand" size={9} />
   </Link>
 );
 

--- a/src/app/data-panel/[id]/page.tsx
+++ b/src/app/data-panel/[id]/page.tsx
@@ -82,8 +82,9 @@ export default async function DataPanel({
         <div className="flex justify-center w-full items-center overflow-hidden">
           <PowerBIContainer panel={panel} pageName={pageName} />
         </div>
-        {catalogHref && <CatalogLink href={catalogHref} />}
       </div>
+
+      {catalogHref && <CatalogLinkSection href={catalogHref} />}
 
       <PanelDescriptionSection panel={panel} />
 
@@ -128,9 +129,15 @@ const MacroThemeLink = ({ href }: { href: string }) => (
   </Link>
 );
 
+const CatalogLinkSection = ({ href }: { href: string }) => (
+  <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-2.5 px-4 py-8 sm:px-6 lg:px-20">
+    <CatalogLink href={href} />
+  </div>
+);
+
 const CatalogLink = ({ href }: { href: string }) => (
   <Link
-    className="mt-4 inline-flex h-10 w-full items-center justify-center gap-3 rounded-md bg-green-800 px-5 text-sm font-medium leading-6 text-white transition hover:bg-green-900"
+    className="inline-flex h-10 w-full items-center justify-center gap-3 rounded-md bg-green-800 px-5 text-sm font-medium leading-6 text-white transition hover:bg-green-900"
     href={href}
   >
     Acessar o catálogo de dados

--- a/src/components/ExploreFilters/ThemeFilterCard.tsx
+++ b/src/components/ExploreFilters/ThemeFilterCard.tsx
@@ -37,7 +37,8 @@ function ThemeFilterCard({
       {href ? (
         <Link
           href={href}
-          className="flex items-center justify-center w-12 h-full shrink-0 transition-colors hover:bg-[#DDEADF] bg-[#F8F7F8]"
+          title="Acesse o tema"
+          className="group/tooltip relative flex items-center justify-center w-12 h-full shrink-0 transition-colors hover:bg-[#DDEADF] bg-[#F8F7F8]"
           onClick={(e) => e.stopPropagation()}
         >
           <Icon
@@ -45,6 +46,9 @@ function ThemeFilterCard({
             id="expand"
             size={10}
           />
+          <span className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-[#292829] px-2 py-1 text-xs font-medium text-white opacity-0 shadow-md transition-opacity group-hover/tooltip:opacity-100">
+            Acesse o tema
+          </span>
         </Link>
       ) : (
         <div className="flex items-center justify-center w-12 h-full shrink-0 transition-colors hover:bg-[#DDEADF] bg-[#F8F7F8]">

--- a/src/components/RelatedPanelsSection/RelatedPanelsSection.tsx
+++ b/src/components/RelatedPanelsSection/RelatedPanelsSection.tsx
@@ -17,7 +17,7 @@ export const RelatedPanelsSection = ({ items }: RelatedPanelsSectionProps) => {
     <section className="w-full bg-white py-10">
       <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-4 sm:px-6 lg:px-20">
         <h2 className="text-[30px] font-semibold leading-[36px] text-[#292829]">
-          Conteúdo Relacionado
+          Conteúdos relacionados
         </h2>
         <RelatedPanelsGrid items={items} />
       </div>

--- a/src/components/SearchResultCard/SearchResultCard.tsx
+++ b/src/components/SearchResultCard/SearchResultCard.tsx
@@ -74,7 +74,7 @@ const SearchResultSummary = ({
       {!showAccessAction && <SearchResultDescription result={result} />}
     </div>
 
-    <Icon className="size-2 min-w-2 rotate-270 md:flex" id="expand" size={9} />
+    <Icon className="size-2 min-w-2 md:flex" id="expand" size={9} />
   </div>
 );
 

--- a/src/utils/queries/macrothemes.ts
+++ b/src/utils/queries/macrothemes.ts
@@ -50,6 +50,7 @@ export const MACROTHEME_PAGE_QUERY = `
       preview: $preview
     ) {
       items {
+        sys { id }
         title
         link
         type
@@ -67,6 +68,7 @@ export const MACROTHEME_PAGE_QUERY = `
       preview: $preview
     ) {
       items {
+        sys { id }
         title
         link
         type
@@ -84,6 +86,7 @@ export const MACROTHEME_PAGE_QUERY = `
       preview: $preview
     ) {
       items {
+        sys { id }
         title
         link
         type
@@ -101,6 +104,7 @@ export const MACROTHEME_PAGE_QUERY = `
       preview: $preview
     ) {
       items {
+        sys { id }
         title
         link
         type


### PR DESCRIPTION
# Description
- Added proper spacing around the “Acessar o catálogo de dados” button on data panel pages.
- Fixed arrow orientation on “Ver mais sobre o tema” so it points to the right.
- Updated the related content section title from “Conteúdo Relacionado” to “Conteúdos relacionados”.
- Fixed arrow orientation on “Acessar” actions in related panel cards.
- Ensured boletim/newsletter cards opened from theme pages route to the internal embedded boletim page instead of the external PDF URL.
- Added an “Acesse o tema” tooltip to the theme arrow action on the “Explore os Dados” page.
