### PR TITLE
Refactor/figma design

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/catalog/page.tsx
+++ b/src/app/catalog/page.tsx
@@ -106,6 +106,13 @@ export default async function CatalogPage({
     slugToTitle,
   );
 
+  const sortedRecords =
+    filterValues.sort === "title_ASC"
+      ? [...initialRecords].sort((a, b) =>
+          a.title.localeCompare(b.title, "pt-BR"),
+        )
+      : initialRecords;
+
   return (
     <HubTemplate>
       {header && <PageHeader content={header} />}
@@ -120,7 +127,7 @@ export default async function CatalogPage({
       <Suspense>
         <DataRecords
           themes={themes}
-          initialRecords={initialRecords}
+          initialRecords={sortedRecords}
           currentPage={catalogRecords.currentPage}
           totalPages={catalogRecords.totalPages}
         />

--- a/src/app/macrothemes/[slug]/page.tsx
+++ b/src/app/macrothemes/[slug]/page.tsx
@@ -85,9 +85,9 @@ export default async function MacroThemePage({
   const theme = themeCollection.items?.[0];
   if (!theme) notFound();
 
-  const postsByThemeHref = `/posts?category=${encodeURIComponent(theme.sys.id)}&type_in=newsletter,additional-content&page=1`;
+  const postsByThemeHref = `/explore?category=${encodeURIComponent(theme.sys.id)}&type_in=newsletter,additional-content&page=1`;
   const dashboardsHref = `/explore?category=${encodeURIComponent(theme.sys.id)}&page=1`;
-  const datastoriesHref = `/posts?category=${encodeURIComponent(theme.sys.id)}&type_in=data-story&page=1`;
+  const datastoriesHref = `/explore?category=${encodeURIComponent(theme.sys.id)}&type_in=data-story&page=1`;
 
   const publicacoes = postCollection.items.filter(
     (post) => post.type === "newsletter" || post.type === "additional-content",

--- a/src/components/DataCard/DataCard.tsx
+++ b/src/components/DataCard/DataCard.tsx
@@ -99,12 +99,6 @@ export const DataCard = ({
 
           <div className="flex flex-wrap items-center gap-3 text-xs text-grey-600">
             <span>Publicado em: {formattedDate}</span>
-            <Link
-              href={`/catalog/${post.id}`}
-              className="font-semibold text-[#018F39] hover:underline"
-            >
-              Ver detalhes
-            </Link>
           </div>
         </div>
 
@@ -167,11 +161,7 @@ export const DataCard = ({
                 variant="secondary"
                 className="w-full border border-[#DCDBDC] bg-transparent"
               >
-                <Link
-                  href={post.html}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <Link href={`/catalog/${post.id}`}>
                   <Icon
                     id="icon-external"
                     size={16}
@@ -232,11 +222,7 @@ export const DataCard = ({
                 variant="secondary"
                 className="bg-transparent border border-1 border-[#DCDBDC] md:w-[225px] w-[100px]"
               >
-                <Link
-                  href={post.html}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <Link href={`/catalog/${post.id}`}>
                   <Icon
                     id="icon-external"
                     size={16}

--- a/src/components/RelatedBoletinsSection/RelatedBoletinsSection.tsx
+++ b/src/components/RelatedBoletinsSection/RelatedBoletinsSection.tsx
@@ -14,7 +14,7 @@ export const RelatedBoletinsSection = ({
     <section className="w-full bg-white py-10">
       <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-4 sm:px-6 lg:px-20">
         <h2 className="text-[30px] font-semibold leading-[36px] text-[#292829]">
-          Conteúdos Relacionados
+          Conteúdos relacionados
         </h2>
         <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           {items.slice(0, 4).map((item) => (

--- a/src/components/RelatedBoletinsSection/RelatedBoletinsSection.tsx
+++ b/src/components/RelatedBoletinsSection/RelatedBoletinsSection.tsx
@@ -1,9 +1,25 @@
 import type { RelatedBoletim } from "@/features/boletim/types";
-import ContentPost from "@/components/ContentPost/ContentPost";
+import { SearchResultCard } from "@/components/SearchResultCard/SearchResultCard";
+import type { SearchResult, SearchItemType } from "@/features/search/types";
 
 type RelatedBoletinsSectionProps = {
   items: RelatedBoletim[];
 };
+
+const toSearchResult = (item: RelatedBoletim): SearchResult => ({
+  id: item.sys.id,
+  source: "post",
+  type: item.type as SearchItemType,
+  title: item.title,
+  description: item.description || "",
+  href: `/boletim/${item.sys.id}`,
+  date: item.date || null,
+  thumb: item.thumb?.url || null,
+  themes: [],
+  tags: [],
+  text: item.title,
+  score: 0,
+});
 
 export const RelatedBoletinsSection = ({
   items,
@@ -19,7 +35,10 @@ export const RelatedBoletinsSection = ({
         <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           {items.slice(0, 4).map((item) => (
             <div key={item.sys.id} className="h-full">
-              <ContentPost content={item} />
+              <SearchResultCard
+                result={toSearchResult(item)}
+                showAccessAction
+              />
             </div>
           ))}
         </div>

--- a/src/components/RelatedPanelsSection/RelatedPanelsSection.tsx
+++ b/src/components/RelatedPanelsSection/RelatedPanelsSection.tsx
@@ -17,7 +17,7 @@ export const RelatedPanelsSection = ({ items }: RelatedPanelsSectionProps) => {
     <section className="w-full bg-white py-10">
       <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-4 sm:px-6 lg:px-20">
         <h2 className="text-[30px] font-semibold leading-[36px] text-[#292829]">
-          Conteúdo Relacionado
+          Conteúdo relacionado
         </h2>
         <RelatedPanelsGrid items={items} />
       </div>

--- a/src/components/SearchResultCard/SearchResultCard.tsx
+++ b/src/components/SearchResultCard/SearchResultCard.tsx
@@ -14,7 +14,7 @@ export const SearchResultCard = ({
   showAccessAction = false,
 }: SearchResultCardProps) => (
   <Link
-    className="group flex h-full w-full flex-col overflow-hidden rounded-md border border-grey-200 bg-grey-100 shadow-md transition duration-300 hover:border-grey-300 hover:bg-grey-200"
+    className="group flex h-full w-full flex-col overflow-hidden rounded-lg border border-[#EFEFEF] bg-white shadow-md transition duration-300 hover:border-grey-300 hover:bg-grey-100"
     href={result.href}
   >
     <SearchResultImage result={result} />
@@ -49,12 +49,12 @@ const SearchResultContent = ({
 );
 
 const SearchResultMeta = ({ result }: { result: SearchResult }) => (
-  <div className="flex flex-row items-center justify-between bg-gray-200 px-5 py-1">
-    <p className="text-xs font-semibold text-grey-1100">
+  <div className="flex flex-row items-center justify-between bg-[#DCDBDC] px-4 py-1">
+    <p className="text-xs font-semibold text-[#0F172A]">
       {getSearchTypeLabel(result)}
     </p>
     {result.date && (
-      <p className="text-xs text-grey-600">
+      <p className="text-[10px] leading-3 text-[#595557]">
         {new Date(result.date).toLocaleDateString("pt-BR")}
       </p>
     )}
@@ -65,16 +65,16 @@ const SearchResultSummary = ({
   result,
   showAccessAction,
 }: SearchResultCardProps) => (
-  <div className="flex h-full items-center justify-between gap-3 px-5 py-4">
+  <div className="flex h-full items-center justify-between gap-3 bg-[#F8F7F8] px-4 py-3">
     <div className="flex min-w-0 flex-1 flex-col gap-2">
       {showAccessAction && <span className="sr-only">{result.title}</span>}
-      <p className="line-clamp-2 text-sm font-medium text-grey-1100">
+      <p className="line-clamp-2 text-sm font-medium leading-5 tracking-[-0.03em] text-[#292829]">
         {showAccessAction ? "Acessar" : result.title}
       </p>
       {!showAccessAction && <SearchResultDescription result={result} />}
     </div>
 
-    <Icon className="size-2 min-w-2 rotate-270 md:flex" id="expand" size={9} />
+    <Icon className="md:flex size-2 min-w-2" id="expand-black" size={9} />
   </div>
 );
 

--- a/src/features/explore/localResults.ts
+++ b/src/features/explore/localResults.ts
@@ -44,7 +44,7 @@ function sortExploreItems(
   sorting: string | null,
 ): SearchIndexItem[] {
   return [...items].sort((left, right) => {
-    if (sorting === sortingTypes["Ordem Alfabética"]) {
+    if (sorting === sortingTypes["Ordem alfabética"]) {
       return left.title.localeCompare(right.title, "pt-BR");
     }
 

--- a/src/lib/zenodo.ts
+++ b/src/lib/zenodo.ts
@@ -91,7 +91,8 @@ export const buildZenodoRecordsQuery = (
     page: page.toString(),
   });
 
-  if (filters.sort) query.append("sort", filters.sort);
+  if (filters.sort && filters.sort !== "title_ASC")
+    query.append("sort", filters.sort);
 
   const { dateCondition, searchCondition, otherConditions } =
     buildConditions(filters);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -55,14 +55,14 @@ export const sortingTypes: {
     | "sys.contentType.sys.id"
     | "-sys.contentType.sys.id";
 } = {
-  "Ordem Alfabética": "title_ASC" as "sys.contentType.sys.id",
   "Mais recente": "date_DESC" as "sys.contentType.sys.id",
+  "Ordem alfabética": "title_ASC" as "sys.contentType.sys.id",
 };
 
 export const dataSortingTypes = {
   "Mais recente": "mostrecent",
-  "Mais visualizados": "mostviewed",
-};
+  "Ordem alfabética": "title_ASC",
+} as const;
 
 export const POST_TYPES = POST_TYPE_LABELS;
 


### PR DESCRIPTION
## Descrição
### Esta PR: 

- Implementa ordenação alfabética dos registros diretamente na página de catálogo quando selecionada.
- Evita o envio do parâmetro `sort=title_ASC` para a API do Zenodo, realizando a ordenação localmente.
- Atualiza links de macrotemas para utilizar a rota `/explore`.
- Altera os cards dos catálogos para direcionarem à página de detalhes do catálogo em vez do link externo (do Zenodo).
- Substitui `ContentPost` por `SearchResultCard` na seção de conteúdos relacionados para padronizar a interface.
- Ajusta o layout e a estilização dos `SearchResultCard` conforme o novo design.
- Padroniza o texto **"Ordem alfabética"** nas constantes e na lógica de ordenação.
- Atualiza a referência de tipos do Next.js (`next-env.d.ts`).