### PR TITLE
fix: standardizes the footers of the cards

### DIFF
--- a/src/components/ContentPost/ContentPost.tsx
+++ b/src/components/ContentPost/ContentPost.tsx
@@ -42,7 +42,7 @@ const ContentPost = ({ content }: { content: IPublication }) => {
         <div className="py-3 px-4 flex gap-4 justify-between h-full items-center box-border bg-[#F8F7F8]">
           <span className="sr-only">{title}</span>
           <p className="line-clamp-2 text-sm font-medium leading-5 tracking-[-0.03em] text-[#292829]">
-            {type === "data-panel" || type === "newsletter" ? "Acessar" : title}
+            Acessar
           </p>
           <Icon className="md:flex size-2 min-w-2" id="expand-black" size={9} />
         </div>


### PR DESCRIPTION
#### This PR standardizes the footers of the cards. They now have only the label "Acessar". 
<img width="379" height="285" alt="image" src="https://github.com/user-attachments/assets/2dfe4a8e-4a68-484d-a11b-bddcf2caf630" />
