### PR TITLE
fix: fixes 'download all' button

### DIFF
--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -7,7 +7,7 @@ export type BrowserDownloadDeps = {
 
 export const browserDownloadDeps: BrowserDownloadDeps = {
   createObjectUrl: (blob) => URL.createObjectURL(blob),
-  fetcher: fetch,
+  fetcher: (...args) => fetch(...args),
   revokeObjectUrl: (url) => URL.revokeObjectURL(url),
   createAnchor: () => document.createElement("a"),
 };


### PR DESCRIPTION
## Description

This PR fixes a runtime `TypeError` when triggering zipped file downloads

## How to test it:

1. Navigate to the catalog page (`/catalog`).
2. Click the `"Baixar todos os arquivos"` button on any dataset card and verify that the download completes without errors.