### PR TITLE
feat: contentful integration on report page

### DIFF
--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,35 +1,51 @@
 import type { Metadata } from "next";
 import type { ReactElement } from "react";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import { ReportBuilder } from "@/components/ReportBuilder/ReportBuilder";
 import { buildMetadata } from "@/config/seo";
-import { getReportThemes } from "@/features/reports/content";
+import { getReportPageData } from "@/features/reports/content";
+import type { ContentfulRichTextField } from "@/utils/interfaces";
 import HubTemplate from "@/templates/HubTemplate";
 
 export const metadata: Metadata = buildMetadata({
-  title: "Relatorio automatico",
+  title: "Relatório automático",
   description:
     "Gere relatorios automaticos do Data Nordeste por municipio e macrotema.",
   path: "/reports",
 });
 
-/** Displays the automatic report builder. Example: `/reports`. */
 export default async function ReportsPage(): Promise<ReactElement> {
-  const themes = await getReportThemes();
+  const { page, themes } = await getReportPageData();
 
   return (
     <HubTemplate>
-      <ReportsHero />
-      <ReportBuilder themes={themes} />
+      <ReportsHero
+        bannerUrl={page?.banner?.url}
+        description={page?.textoDoBanner}
+      />
+      <ReportBuilder
+        themes={themes}
+        municipalityText={page?.textoDoMunicipio}
+        themeText={page?.textoDoTema}
+      />
     </HubTemplate>
   );
 }
 
-function ReportsHero(): ReactElement {
+function ReportsHero({
+  bannerUrl,
+  description,
+}: {
+  bannerUrl?: string;
+  description?: ContentfulRichTextField;
+}): ReactElement {
   return (
     <section className="relative h-[226px] w-full overflow-hidden sm:h-[220px]">
       <div
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"
-        style={{ backgroundImage: "url('/banner.png')" }}
+        style={{
+          backgroundImage: `url(${bannerUrl ?? "/banner.png"})`,
+        }}
       />
       <div className="absolute inset-0 bg-[linear-gradient(90deg,#000_0%,rgba(0,0,0,0.78)_34%,rgba(0,0,0,0.12)_100%)]" />
       <div className="relative z-10 mx-auto flex h-full w-full max-w-[1440px] items-center px-4 sm:px-6 lg:px-10">
@@ -37,11 +53,17 @@ function ReportsHero(): ReactElement {
           <h1 className="text-[34px] font-extrabold leading-[40px] text-grey-100 sm:text-[48px] sm:leading-[52px]">
             Relatório Automático
           </h1>
-          <p className="text-sm font-medium leading-6 text-grey-100 sm:text-lg">
-            Explore os principais painéis de dados do Data Nordeste e tenha uma
-            visão dinâmica, visual e interativa, facilitando a compreensão dos
-            principais indicadores da região.
-          </p>
+          {description ? (
+            <div className="text-sm font-medium leading-6 text-grey-100 sm:text-lg">
+              {documentToReactComponents(description.json)}
+            </div>
+          ) : (
+            <p className="text-sm font-medium leading-6 text-grey-100 sm:text-lg">
+              Explore os principais painéis de dados do Data Nordeste e tenha
+              uma visão dinâmica, visual e interativa, facilitando a compreensão
+              dos principais indicadores da região.
+            </p>
+          )}
         </div>
       </div>
     </section>

--- a/src/components/ReportBuilder/ReportBuilder.tsx
+++ b/src/components/ReportBuilder/ReportBuilder.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/Icon/Icon";
 import ThemeFilterCard from "@/components/ExploreFilters/ThemeFilterCard";
@@ -19,18 +20,24 @@ import {
   getAutomaticReportSlug,
   type AutomaticReportMacrothemeSlug,
 } from "@/features/reports/automaticReport";
+import type { ContentfulRichTextField, MacroTheme } from "@/utils/interfaces";
 import { normalizeKey, sortContentByDesiredOrder } from "@/utils/functions";
-import type { MacroTheme } from "@/utils/interfaces";
 
 type ReportTheme = Pick<MacroTheme, "id" | "name" | "color" | "sys">;
 type ReportMobileTab = "config" | "report";
 
 type ReportBuilderProps = {
   themes: ReportTheme[];
+  municipalityText?: ContentfulRichTextField;
+  themeText?: ContentfulRichTextField;
 };
 
 /** Renders the automatic report form. Example: `<ReportBuilder themes={themes} />`. */
-export function ReportBuilder({ themes }: ReportBuilderProps): ReactElement {
+export function ReportBuilder({
+  themes,
+  municipalityText,
+  themeText,
+}: ReportBuilderProps): ReactElement {
   const [municipality, setMunicipality] = useState("");
   const [selectedThemeIds, setSelectedThemeIds] = useState<string[]>([]);
   const [cities, setCities] = useState<string[]>([]);
@@ -92,6 +99,7 @@ export function ReportBuilder({ themes }: ReportBuilderProps): ReactElement {
       errorMessage={errorMessage}
       loadingCities={loadingCities}
       municipality={municipality}
+      municipalityText={municipalityText}
       onClear={clearSelectedThemes}
       onGenerate={generateReport}
       onMunicipalityChange={setMunicipality}
@@ -101,6 +109,7 @@ export function ReportBuilder({ themes }: ReportBuilderProps): ReactElement {
       reportPreview={reportPreview}
       selectedThemeIds={selectedThemeIds}
       themes={sortedThemes}
+      themeText={themeText}
     />
   );
 }
@@ -112,6 +121,7 @@ function ReportBuilderLayout({
   errorMessage,
   loadingCities,
   municipality,
+  municipalityText,
   onClear,
   onGenerate,
   onMunicipalityChange,
@@ -121,6 +131,7 @@ function ReportBuilderLayout({
   reportPreview,
   selectedThemeIds,
   themes,
+  themeText,
 }: {
   activeTab: ReportMobileTab;
   allThemesSelected: boolean;
@@ -128,6 +139,7 @@ function ReportBuilderLayout({
   errorMessage: string;
   loadingCities: boolean;
   municipality: string;
+  municipalityText?: ContentfulRichTextField;
   onClear: () => void;
   onGenerate: () => void;
   onMunicipalityChange: (value: string) => void;
@@ -137,6 +149,7 @@ function ReportBuilderLayout({
   reportPreview: ReportPreviewDocument | null;
   selectedThemeIds: string[];
   themes: ReportTheme[];
+  themeText?: ContentfulRichTextField;
 }): ReactElement {
   return (
     <section className="w-full bg-white">
@@ -154,6 +167,7 @@ function ReportBuilderLayout({
           <MunicipalityField
             cities={cities}
             loadingCities={loadingCities}
+            municipalityText={municipalityText}
             onChange={onMunicipalityChange}
             value={municipality}
           />
@@ -164,6 +178,7 @@ function ReportBuilderLayout({
             onToggleTheme={onToggleTheme}
             selectedThemeIds={selectedThemeIds}
             themes={themes}
+            themeText={themeText}
           />
           {errorMessage && <ReportErrorMessage message={errorMessage} />}
           <ReportSubmitButton onClick={onGenerate} />
@@ -243,7 +258,7 @@ function ReportSectionHeader({
   subtitle,
   title,
 }: {
-  subtitle: string;
+  subtitle: ReactNode;
   title: string;
 }): ReactElement {
   return (
@@ -251,9 +266,9 @@ function ReportSectionHeader({
       <h2 className="text-2xl font-semibold leading-9 tracking-tight text-[#292829]">
         {title}
       </h2>
-      <p className="text-base font-normal leading-relaxed text-[#292829]">
+      <div className="text-base font-normal leading-relaxed text-[#292829]">
         {subtitle}
-      </p>
+      </div>
     </div>
   );
 }
@@ -263,16 +278,22 @@ function MunicipalityField({
   loadingCities,
   onChange,
   value,
+  municipalityText,
 }: {
   cities: string[];
   loadingCities: boolean;
   onChange: (value: string) => void;
   value: string;
+  municipalityText?: ContentfulRichTextField;
 }): ReactElement {
   return (
     <>
       <ReportSectionHeader
-        subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        subtitle={
+          municipalityText
+            ? documentToReactComponents(municipalityText.json)
+            : "Selecione o município para gerar o relatório."
+        }
         title="Selecione o município"
       />
       <MunicipalitySearch cities={cities} onChange={onChange} value={value} />
@@ -328,6 +349,7 @@ function ReportThemesField({
   onToggleTheme,
   selectedThemeIds,
   themes,
+  themeText,
 }: {
   allThemesSelected: boolean;
   onClear: () => void;
@@ -335,11 +357,16 @@ function ReportThemesField({
   onToggleTheme: (themeId: string) => void;
   selectedThemeIds: string[];
   themes: ReportTheme[];
+  themeText?: ContentfulRichTextField;
 }): ReactElement {
   return (
     <div className="mt-6">
       <ReportSectionHeader
-        subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        subtitle={
+          themeText
+            ? documentToReactComponents(themeText.json)
+            : "Escolha um ou mais macrotemas para compor o relatório."
+        }
         title="Selecione os temas"
       />
       <ReportThemeActions onClear={onClear} />
@@ -368,7 +395,7 @@ function ReportThemeActions({
         onClick={onClear}
         type="button"
       >
-        Limpar Seleções
+        Limpar seleções
         <Icon id="trash" size={14} />
       </button>
     </div>
@@ -443,7 +470,7 @@ function ReportSubmitButton({
       type="button"
     >
       <Icon id="file-text" size={12} />
-      Gerar Relatório
+      Gerar relatório
     </Button>
   );
 }

--- a/src/features/reports/content.ts
+++ b/src/features/reports/content.ts
@@ -1,36 +1,37 @@
 import { unstable_cache } from "next/cache";
+import { REPORT_PAGE_QUERY } from "@/utils/queries/reports";
 import { REVALIDATE } from "@/utils/constants";
 import { getContent } from "@/utils/contentful";
-import type { MacroTheme } from "@/utils/interfaces";
+import type { ContentfulRichTextField, MacroTheme } from "@/utils/interfaces";
 
-type ReportPageContent = {
-  themeCollection: {
-    items: MacroTheme[];
-  };
+export type ReportPage = {
+  banner?: { url: string };
+  textoDoBanner?: ContentfulRichTextField;
+  textoDoMunicipio?: ContentfulRichTextField;
+  textoDoTema?: ContentfulRichTextField;
 };
 
-const REPORT_PAGE_QUERY = `
-  query GetReportPageThemes($preview: Boolean) {
-    themeCollection(limit: 30, preview: $preview) {
-      items {
-        name
-        id
-        color
-        sys {
-          id
-        }
-      }
-    }
-  }
-`;
+type ReportPageContent = {
+  reportCollection: { items: ReportPage[] };
+  themeCollection: { items: MacroTheme[] };
+};
 
-/** Loads macrothemes used by the report builder. Example: `await getReportThemes()`. */
-export const getReportThemes = unstable_cache(
-  async (): Promise<MacroTheme[]> => {
+export type ReportPageData = {
+  themes: MacroTheme[];
+  page: ReportPage | null;
+};
+
+/** Loads the report page content and macrothemes. Example: `await getReportPageData()`. */
+export const getReportPageData = unstable_cache(
+  async (): Promise<ReportPageData> => {
     const content = await getContent<ReportPageContent>(REPORT_PAGE_QUERY);
+    const page = content.reportCollection.items[0] ?? null;
 
-    return content.themeCollection.items.filter(Boolean);
+    return {
+      page,
+      themes: content.themeCollection.items.filter(Boolean),
+    };
   },
-  ["report-page-themes"],
+  ["report-page-data"],
   { revalidate: REVALIDATE },
 );

--- a/src/utils/queries/reports.test.ts
+++ b/src/utils/queries/reports.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { REPORT_PAGE_QUERY } from "./reports";
+
+describe("REPORT_PAGE_QUERY", () => {
+  it("requests the banner image and every rich text rendered on the page", () => {
+    expect(REPORT_PAGE_QUERY).toMatch(
+      /reportCollection[\s\S]*banner\s*{\s*url\s*}/,
+    );
+    expect(REPORT_PAGE_QUERY).toMatch(
+      /reportCollection[\s\S]*textoDoBanner\s*{\s*json\s*}/,
+    );
+    expect(REPORT_PAGE_QUERY).toMatch(
+      /reportCollection[\s\S]*textoDoMunicipio\s*{\s*json\s*}/,
+    );
+    expect(REPORT_PAGE_QUERY).toMatch(
+      /reportCollection[\s\S]*textoDoTema\s*{\s*json\s*}/,
+    );
+  });
+
+  it("still loads the macrotheme list used by the builder", () => {
+    expect(REPORT_PAGE_QUERY).toMatch(/themeCollection[\s\S]*name/);
+    expect(REPORT_PAGE_QUERY).toMatch(/themeCollection[\s\S]*sys\s*{\s*id\s*}/);
+  });
+});

--- a/src/utils/queries/reports.ts
+++ b/src/utils/queries/reports.ts
@@ -1,0 +1,40 @@
+/**
+ * GraphQL query used by the report page (`/reports`).
+ * Mirrors the shape used by `about.ts`, `connections.ts`, etc.: page‑level
+ * banner + copy live in their own collection (`reportCollection`), while the
+ * macrotemes used by the form come from `themeCollection`.
+ *
+ * `limit: 1` + ordering by creation date is the safe fallback for a single
+ * editorial entry that owns the page; filtering by a slug field would require
+ * that field to be queryable, which Contentful does not always expose.
+ */
+export const REPORT_PAGE_QUERY = `
+  query GetReportPageContent($preview: Boolean) {
+    reportCollection(limit: 1, preview: $preview) {
+      items {
+        banner {
+          url
+        }
+        textoDoBanner {
+          json
+        }
+        textoDoMunicipio {
+          json
+        }
+        textoDoTema {
+          json
+        }
+      }
+    }
+    themeCollection(limit: 30, preview: $preview) {
+      items {
+        name
+        id
+        color
+        sys {
+          id
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Description
This PR features the /reports page to now render its hero banner, hero description, and the two section subtitles (Municipality, Themes) from a new report content type in Contentful instead of hard-coded copy.
- **src/utils/queries/reports.ts (new)**: REPORT_PAGE_QUERY selecting banner { url }, textoDoBanner { json }, textoDoMunicipio { json }, textoDoTema { json } from reportCollection(limit: 1), plus themeCollection for the macrotheme list.
- **src/utils/queries/reports.test.ts (new)**: asserts the query selects every field consumed by the page.
- **src/features/reports/content.ts:** reduced to a thin wrapper. Single export getReportPageData, wrapped in unstable_cache, returning { page, themes }. No more duplicate fetcher.
- **src/app/reports/page.tsx**: calls getReportPageData, passes bannerUrl and description (rich‑text textoDoBanner) to ReportsHero, and municipalityText/themeText to ReportBuilder. Static copy kept as a fallback when Contentful returns nothing.
- **src/components/ReportBuilder/ReportBuilder.tsx**: ReportSectionHeader now accepts ReactNode; MunicipalityField and ReportThemesField render rich text via documentToReactComponents. Section titles stay hard‑coded as in the other pages.