### PR TITLE
feat: route Contentful assets through the local cache proxy

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,12 +13,6 @@ const nextConfig = {
         pathname: "**",
       },
       {
-        protocol: "https",
-        hostname: "images.ctfassets.net",
-        port: "",
-        pathname: "**",
-      },
-      {
         protocol: "http",
         hostname: "servicosweb.cnpq.br",
         port: "",

--- a/src/utils/contentful.test.ts
+++ b/src/utils/contentful.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildContentfulEndpoint, createContentfulClient } from "./contentful";
+import {
+  buildContentfulEndpoint,
+  createContentfulClient,
+  getCachedContentfulAssetUrl,
+} from "./contentful";
 
 const createResponse = ({
   body,
@@ -38,6 +42,20 @@ describe("Contentful client", () => {
     ).toBe("https://portal.example.com/contentful-api");
   });
 
+  it("maps Contentful asset URLs to the local cache proxy", () => {
+    expect(
+      getCachedContentfulAssetUrl(
+        "https://images.ctfassets.net/space/asset/banner.jpg?w=1200&fm=webp",
+      ),
+    ).toBe("/contentful-assets/space/asset/banner.jpg?w=1200&fm=webp");
+    expect(
+      getCachedContentfulAssetUrl("//images.ctfassets.net/space/asset/icon.svg"),
+    ).toBe("/contentful-assets/space/asset/icon.svg");
+    expect(getCachedContentfulAssetUrl("https://example.com/banner.jpg")).toBe(
+      "https://example.com/banner.jpg",
+    );
+  });
+
   it("sends preview variables, headers, and revalidation options", async () => {
     const fetcher = vi.fn(async () =>
       createResponse({ body: { data: { ok: true } } }),
@@ -68,6 +86,31 @@ describe("Contentful client", () => {
         }),
       }),
     );
+  });
+
+  it("normalizes Contentful asset URLs in nested GraphQL data", async () => {
+    const client = createContentfulClient({
+      endpoint: "https://contentful.example.com/graphql",
+      fetcher: vi.fn(async () =>
+        createResponse({
+          body: {
+            data: {
+              banner: {
+                url: "https://images.ctfassets.net/space/asset/banner.jpg?w=800",
+              },
+              external: { url: "https://example.com/image.jpg" },
+            },
+          },
+        }),
+      ) as unknown as typeof fetch,
+      preview: true,
+      revalidate: 60,
+    });
+
+    await expect(client("query Home")).resolves.toEqual({
+      banner: { url: "/contentful-assets/space/asset/banner.jpg?w=800" },
+      external: { url: "https://example.com/image.jpg" },
+    });
   });
 
   it("throws readable errors for HTTP and GraphQL failures", async () => {

--- a/src/utils/contentful.ts
+++ b/src/utils/contentful.ts
@@ -51,6 +51,42 @@ type ContentfulGraphqlResponse<T> = {
 };
 
 const UNRESOLVABLE_LINK = "UNRESOLVABLE_LINK";
+const CONTENTFUL_ASSET_HOST = "images.ctfassets.net";
+const CONTENTFUL_ASSET_PROXY_PATH = "/contentful-assets";
+
+type ContentfulResponseObject = { [key: string]: unknown };
+
+export function getCachedContentfulAssetUrl(url: string): string {
+  const absoluteUrl = url.startsWith("//") ? `https:${url}` : url;
+
+  try {
+    const parsedUrl = new URL(absoluteUrl);
+
+    return parsedUrl.hostname === CONTENTFUL_ASSET_HOST
+      ? `${CONTENTFUL_ASSET_PROXY_PATH}${parsedUrl.pathname}${parsedUrl.search}`
+      : url;
+  } catch {
+    return url;
+  }
+}
+
+function normalizeContentfulAssetUrls<T>(content: T): T {
+  if (Array.isArray(content)) {
+    content.forEach(normalizeContentfulAssetUrls);
+    return content;
+  }
+
+  if (content === null || typeof content !== "object") return content;
+
+  const fields = content as ContentfulResponseObject;
+  Object.entries(fields).forEach(([key, value]) => {
+    fields[key] = key === "url" && typeof value === "string"
+      ? getCachedContentfulAssetUrl(value)
+      : normalizeContentfulAssetUrls(value);
+  });
+
+  return content;
+}
 
 function isUnresolvableLink(error: ContentfulGraphqlError): boolean {
   return error.extensions?.contentful?.code === UNRESOLVABLE_LINK;
@@ -144,7 +180,9 @@ export function createContentfulClient({
 
     const json = (await response.json()) as ContentfulGraphqlResponse<T>;
 
-    return requireContentfulData(json, finalVariables);
+    return normalizeContentfulAssetUrls(
+      requireContentfulData(json, finalVariables),
+    );
   };
 }
 


### PR DESCRIPTION
## Summary
Routes Contentful asset URLs through the local /contentful-assets/ proxy so Nginx can cache them.

## Changes
- Rewrites images.ctfassets.net URLs returned by Contentful GraphQL.
- Preserves asset paths and image transformation query parameters.
- Removes the direct Contentful remote image pattern from Next.js.
- Adds coverage for URL normalization and nested Contentful responses.