### PR TITLE
feat: select multiple macrothemes to generate report

### DIFF
--- a/src/components/ReportBuilder/ReportBuilder.tsx
+++ b/src/components/ReportBuilder/ReportBuilder.tsx
@@ -18,6 +18,7 @@ import {
 import {
   buildReportProxyUrl,
   getAutomaticReportSlug,
+  joinReportSlugs,
   type AutomaticReportMacrothemeSlug,
 } from "@/features/reports/automaticReport";
 import type { ContentfulRichTextField, MacroTheme } from "@/utils/interfaces";
@@ -80,7 +81,9 @@ export function ReportBuilder({
   const generateReport = async (): Promise<void> => {
     const request = buildReportRequest(municipality, selectedThemeIds);
     if (!request) {
-      setErrorMessage("Selecione um município e um macrotema disponível.");
+      setErrorMessage(
+        "Selecione um município e ao menos um macrotema disponível.",
+      );
 
       return;
     }
@@ -503,13 +506,12 @@ function toggleThemeId(
   themeId: string,
   supportedThemeIds: string[],
 ): string[] {
+  if (!supportedThemeIds.includes(themeId)) return currentIds;
   if (currentIds.includes(themeId)) {
-    if (currentIds.length > 1) return [themeId];
-
     return currentIds.filter((id) => id !== themeId);
   }
 
-  return supportedThemeIds.includes(themeId) ? [themeId] : currentIds;
+  return [...currentIds, themeId];
 }
 
 function getSupportedThemeIds(themes: ReportTheme[]): string[] {
@@ -531,19 +533,20 @@ function hasSelectedAllThemes(
 function buildReportRequest(
   city: string,
   selectedThemeIds: string[],
-): { city: string; macrotheme: AutomaticReportMacrothemeSlug } | null {
+): { city: string; macrotheme: string } | null {
   const macrotheme = resolveSelectedMacrotheme(selectedThemeIds);
   if (!city.trim() || !macrotheme) return null;
 
   return { city: city.trim(), macrotheme };
 }
 
-function resolveSelectedMacrotheme(
-  selectedThemeIds: string[],
-): AutomaticReportMacrothemeSlug | null {
-  if (selectedThemeIds.length > 1) return "todos";
+function resolveSelectedMacrotheme(selectedThemeIds: string[]): string | null {
+  const slugs = selectedThemeIds
+    .map((themeId) => getAutomaticReportSlug(themeId))
+    .filter((slug): slug is AutomaticReportMacrothemeSlug => Boolean(slug));
+  if (slugs.length === 0) return null;
 
-  return getAutomaticReportSlug(selectedThemeIds[0] ?? "");
+  return joinReportSlugs(slugs);
 }
 
 async function loadReportCities(
@@ -569,7 +572,7 @@ const REPORT_STATUS_MAX_ATTEMPTS = 60;
 
 async function requestReportPreview(request: {
   city: string;
-  macrotheme: AutomaticReportMacrothemeSlug;
+  macrotheme: string;
 }): Promise<ReportPreviewDocument> {
   const generationUrl = buildReportProxyUrl(request);
   const startResponse = await fetch(generationUrl, { method: "POST" });

--- a/src/features/reports/automaticReport.ts
+++ b/src/features/reports/automaticReport.ts
@@ -9,7 +9,7 @@ export type AutomaticReportMacrothemeSlug =
 
 export type AutomaticReportRequest = {
   city: string;
-  macrotheme: AutomaticReportMacrothemeSlug;
+  macrotheme: string;
 };
 
 const AUTOMATIC_REPORT_SLUGS = new Set<AutomaticReportMacrothemeSlug>([
@@ -40,27 +40,51 @@ export function getAutomaticReportSlug(
   return REPORT_SLUG_BY_THEME_ID[themeId] ?? null;
 }
 
-/** Validates report slugs accepted by Automatic-Reporting. Example: `parseAutomaticReportSlug("saude")`. */
+/** Validates one or more comma-separated report slugs. Example: `parseAutomaticReportSlug("saude,demografia")`. */
 export function parseAutomaticReportSlug(
   value: string | null,
-): AutomaticReportMacrothemeSlug {
-  if (
-    value &&
-    AUTOMATIC_REPORT_SLUGS.has(value as AutomaticReportMacrothemeSlug)
-  ) {
-    return value as AutomaticReportMacrothemeSlug;
+): AutomaticReportMacrothemeSlug[] {
+  if (!value) {
+    throw new Error(
+      `Invalid macrotheme "${value}"; expected one or more of ${Array.from(AUTOMATIC_REPORT_SLUGS).join(", ")}.`,
+    );
   }
 
-  throw new Error(
-    `Invalid macrotheme "${value}"; expected one of ${Array.from(AUTOMATIC_REPORT_SLUGS).join(", ")}.`,
+  const slugs = value
+    .split(",")
+    .map((slug) => slug.trim())
+    .filter(Boolean);
+  if (slugs.length === 0) {
+    throw new Error(
+      `Invalid macrotheme "${value}"; expected at least one of ${Array.from(AUTOMATIC_REPORT_SLUGS).join(", ")}.`,
+    );
+  }
+
+  const invalid = slugs.filter(
+    (slug) =>
+      !AUTOMATIC_REPORT_SLUGS.has(slug as AutomaticReportMacrothemeSlug),
   );
+  if (invalid.length > 0) {
+    throw new Error(
+      `Invalid macrotheme "${value}"; expected only entries from ${Array.from(AUTOMATIC_REPORT_SLUGS).join(", ")}.`,
+    );
+  }
+
+  return slugs as AutomaticReportMacrothemeSlug[];
+}
+
+/** Joins macrotheme slugs into the comma-separated wire format. Example: `joinReportSlugs(["saude","demografia"])` => `"saude,demografia"`. */
+export function joinReportSlugs(
+  slugs: AutomaticReportMacrothemeSlug[],
+): string {
+  return slugs.join(",");
 }
 
 /**
  * Builds the public Next proxy URL for a generated report PDF.
  *
- * Example: `buildReportProxyUrl({ city, macrotheme })` =>
- * `/api/reports/generate?city=Recife%20(PE)&macrotema=saude&_=1721600000000`.
+ * Example: `buildReportProxyUrl({ city, macrotheme: "saude,demografia" })` =>
+ * `/api/reports/generate?city=Recife%20(PE)&macrotema=saude%2Cdemografia&_=1721600000000`.
  */
 export function buildReportProxyUrl(request: AutomaticReportRequest): string {
   const params = new URLSearchParams({

--- a/src/features/reports/reportGateway.ts
+++ b/src/features/reports/reportGateway.ts
@@ -1,6 +1,8 @@
 import {
   getAutomaticReportApiBaseUrl,
+  joinReportSlugs,
   parseAutomaticReportSlug,
+  type AutomaticReportMacrothemeSlug,
 } from "@/features/reports/automaticReport";
 
 type AutomaticReportEntry = {
@@ -20,12 +22,16 @@ export function buildAutomaticReportGenerationUrl(
   params: URLSearchParams,
 ): string {
   const city = requireCity(params);
-  const macrotheme = parseAutomaticReportSlug(params.get("macrotema"));
+  const slugs = parseAutomaticReportSlug(params.get("macrotema"));
   const url = new URL(
     `/relatorio/${encodeURIComponent(city)}`,
     getAutomaticReportApiBaseUrl(),
   );
-  url.searchParams.set("macrotema", macrotheme);
+
+  // PERF: The backend accepts a comma-separated list in a single `macrotema`
+  // query param. Keeping the legacy single-value shape avoids a new contract
+  // while letting users request several macrothemes in one shot.
+  url.searchParams.set("macrotema", joinReportSlugs(slugs));
 
   return url.toString();
 }
@@ -35,25 +41,37 @@ export async function findAvailableAutomaticReport(
   params: URLSearchParams,
 ): Promise<AvailableAutomaticReport | null> {
   const city = requireCity(params);
-  const macrotheme = parseAutomaticReportSlug(params.get("macrotema"));
+  const slugs = parseAutomaticReportSlug(params.get("macrotema"));
   const reports = await fetchReportIndex();
   const report = reports.find(
     (entry) =>
       Boolean(entry.pdf_url) &&
       matchesReportCity(entry.cidade, city) &&
-      normalizeReportLabel(entry.arquivo_pdf).includes(
-        normalizeReportLabel(macrotheme),
-      ),
+      entryMatchesAnyMacrotheme(entry.arquivo_pdf, slugs),
   );
   if (!report) return null;
 
   return {
     fileName: report.arquivo_pdf,
-    pdfUrl: new URL(
-      report.pdf_url,
-      getAutomaticReportApiBaseUrl(),
-    ).toString(),
+    pdfUrl: new URL(report.pdf_url, getAutomaticReportApiBaseUrl()).toString(),
   };
+}
+
+/**
+ * Matches a report filename against any of the requested macrotheme slugs.
+ * The backend writes one PDF per macrotheme per city, so "any match" returns
+ * the first ready one. This is intentional: when multiple themes are selected,
+ * the client polls for whichever becomes available first.
+ */
+function entryMatchesAnyMacrotheme(
+  fileName: string,
+  slugs: AutomaticReportMacrothemeSlug[],
+): boolean {
+  const normalizedFileName = normalizeReportLabel(fileName);
+
+  return slugs.some((slug) =>
+    normalizedFileName.includes(normalizeReportLabel(slug)),
+  );
 }
 
 function matchesReportCity(entryCity: string, requestedCity: string): boolean {
@@ -78,10 +96,9 @@ function requireCity(params: URLSearchParams): string {
 }
 
 async function fetchReportIndex(): Promise<AutomaticReportEntry[]> {
-  const response = await fetch(
-    `${getAutomaticReportApiBaseUrl()}/relatorios`,
-    { cache: "no-store" },
-  );
+  const response = await fetch(`${getAutomaticReportApiBaseUrl()}/relatorios`, {
+    cache: "no-store",
+  });
   if (!response.ok) {
     throw new Error(
       `Automatic report index returned ${response.status}; expected 200.`,
@@ -92,9 +109,7 @@ async function fetchReportIndex(): Promise<AutomaticReportEntry[]> {
 }
 
 function normalizeLegacyReportLabel(value: string): string {
-  return value
-    .replaceAll(/[^a-zA-Z0-9]/g, "")
-    .toLowerCase();
+  return value.replaceAll(/[^a-zA-Z0-9]/g, "").toLowerCase();
 }
 
 function normalizeReportLabel(value: string): string {

--- a/src/utils/contentful.ts
+++ b/src/utils/contentful.ts
@@ -73,6 +73,7 @@ export function getCachedContentfulAssetUrl(url: string): string {
 function normalizeContentfulAssetUrls<T>(content: T): T {
   if (Array.isArray(content)) {
     content.forEach(normalizeContentfulAssetUrls);
+
     return content;
   }
 
@@ -80,9 +81,10 @@ function normalizeContentfulAssetUrls<T>(content: T): T {
 
   const fields = content as ContentfulResponseObject;
   Object.entries(fields).forEach(([key, value]) => {
-    fields[key] = key === "url" && typeof value === "string"
-      ? getCachedContentfulAssetUrl(value)
-      : normalizeContentfulAssetUrls(value);
+    fields[key] =
+      key === "url" && typeof value === "string"
+        ? getCachedContentfulAssetUrl(value)
+        : normalizeContentfulAssetUrls(value);
   });
 
   return content;


### PR DESCRIPTION
## Description 
Changes the report generation form from single-select to multi-select macrotheme
selection. Users can now pick any combination of supported themes — the backend
receives slugs joined by comma (e.g. `saude,demografia`) instead of the synthetic
`"todos"` placeholder.

## Changes

### Form behaviour (`ReportBuilder.tsx`)

- `toggleThemeId` now **adds** an unchecked theme to the selection instead of
  replacing the current one — true multi-select via checkboxes.
- `resolveSelectedMacrotheme` joins all selected slugs with `,` instead of
  returning the legacy `"todos"` synthetic slug.
- Request type widened from `AutomaticReportMacrothemeSlug` to `string` — the
  field now holds the joined slug list.

### Wire format & validation (`automaticReport.ts`)

- `parseAutomaticReportSlug` now accepts a comma-separated list and returns
  `AutomaticReportMacrothemeSlug[]` — validates every entry.
- New `joinReportSlugs(...)` helper to serialise slug arrays.
- `AutomaticReportRequest.macrotheme` is now a plain `string` to accommodate
  both single and multi-theme payloads.
- `"todos"` remains valid for backward compatibility with older generated PDFs.

### Proxy gateway (`reportGateway.ts`)

- The upstream URL still uses a single `macrotema` query param — the joined
  list is kept as one value (no new API contract needed).
- `findAvailableAutomaticReport` now matches the report index entry against
  **any** of the requested slugs via `entryMatchesAnyMacrotheme`. The first
  ready PDF wins, matching the existing polling behaviour.
