### PR TITLE
Fix/polling

### DIFF
--- a/src/app/api/reports/download/route.ts
+++ b/src/app/api/reports/download/route.ts
@@ -6,6 +6,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const report = await findAvailableAutomaticReport(
       request.nextUrl.searchParams,
+      request.nextUrl.searchParams.get("gerado_apos"),
     );
     if (!report) {
       return NextResponse.json(

--- a/src/app/api/reports/generate/route.test.ts
+++ b/src/app/api/reports/generate/route.test.ts
@@ -29,21 +29,35 @@ class AutomaticReportFetchFake {
 
   private reportIndexResponse(): Response {
     return Response.json([
-      this.reportEntry("Salvador Ba", "/output/relatorio_saude__salvador.pdf"),
-      this.reportEntry("Recife Pe", "/output/relatorio_saude__recife.pdf"),
+      this.reportEntry(
+        "Salvador Ba",
+        "/output/relatorio_saude__salvador.pdf",
+        "2026-08-03T10:00:00.000Z",
+      ),
+      this.reportEntry(
+        "Recife Pe",
+        "/output/relatorio_saude__recife.pdf",
+        "2026-08-03T10:00:00.000Z",
+      ),
       this.reportEntry(
         "Bel M Al",
         "/output/relatorio_economia-renda__bel_m_al_.pdf",
+        "2026-08-03T10:00:00.000Z",
       ),
     ]);
   }
 
-  private reportEntry(cidade: string, pdfUrl: string): object {
+  private reportEntry(
+    cidade: string,
+    pdfUrl: string,
+    lastModifiedUtc: string,
+  ): object {
     return {
       arquivo_pdf: pdfUrl.split("/").at(-1),
       cidade,
       macrotema: "Saúde",
       pdf_url: pdfUrl,
+      last_modified_utc: lastModifiedUtc,
     };
   }
 
@@ -130,5 +144,43 @@ describe("automatic report generation proxy", () => {
     expect(automaticReportApi.requestedUrls.at(-1)).toBe(
       `${API_URL}/output/relatorio_saude__recife.pdf`,
     );
+  });
+
+  it("ignores stale reports when gerado_apos is newer than the last PDF", async () => {
+    const automaticReportApi = new AutomaticReportFetchFake();
+    vi.stubGlobal("fetch", automaticReportApi.fetch);
+    vi.stubEnv("NEXT_PUBLIC_AUTOMATIC_REPORT_API_URL", API_URL);
+
+    // Index entries are dated 2026-08-03; ask for anything written after the
+    // next day. No entry should match, so the proxy must keep polling.
+    const request = new NextRequest(
+      "http://localhost/api/reports/generate?city=Recife%20(PE)&macrotema=saude&gerado_apos=2026-08-04T17%3A01%3A17.000Z",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({ status: "processing" });
+  });
+
+  it("accepts a fresh report when gerado_apos predates the last PDF", async () => {
+    const automaticReportApi = new AutomaticReportFetchFake();
+    vi.stubGlobal("fetch", automaticReportApi.fetch);
+    vi.stubEnv("NEXT_PUBLIC_AUTOMATIC_REPORT_API_URL", API_URL);
+
+    // Index entries are dated 2026-08-03; ask for anything written after the
+    // day before — the entry should be accepted.
+    const request = new NextRequest(
+      "http://localhost/api/reports/generate?city=Recife%20(PE)&macrotema=saude&gerado_apos=2026-08-02T00%3A00%3A00.000Z",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "ready",
+      fileName: "relatorio_saude__recife.pdf",
+      url: "/api/reports/download?city=Recife%20(PE)&macrotema=saude&gerado_apos=2026-08-02T00%3A00%3A00.000Z",
+    });
   });
 });

--- a/src/app/api/reports/generate/route.ts
+++ b/src/app/api/reports/generate/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const report = await findAvailableAutomaticReport(
       request.nextUrl.searchParams,
+      request.nextUrl.searchParams.get("gerado_apos"),
     );
     if (!report) {
       return NextResponse.json({ status: "processing" }, { status: 202 });

--- a/src/components/ReportBuilder/ReportBuilder.tsx
+++ b/src/components/ReportBuilder/ReportBuilder.tsx
@@ -578,7 +578,8 @@ async function requestReportPreview(request: {
   city: string;
   macrotheme: string;
 }): Promise<ReportPreviewDocument> {
-  const generationUrl = buildReportProxyUrl(request);
+  const geradoApos = new Date().toISOString();
+  const generationUrl = buildReportProxyUrl({ ...request, geradoApos });
   const startResponse = await fetch(generationUrl, { method: "POST" });
   if (!startResponse.ok) throw new Error(`status ${startResponse.status}`);
 

--- a/src/features/reports/automaticReport.test.ts
+++ b/src/features/reports/automaticReport.test.ts
@@ -31,4 +31,18 @@ describe("automatic report proxy URL", () => {
       "/api/reports/generate?city=Recife+%28PE%29&macrotema=demografia&_=1000",
     );
   });
+
+  it("includes the gerado_apos freshness cursor when provided", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+
+    const url = buildReportProxyUrl({
+      city: "Recife (PE)",
+      macrotheme: "demografia",
+      geradoApos: "2026-08-04T17:01:17.000Z",
+    });
+
+    expect(url).toBe(
+      "/api/reports/generate?city=Recife+%28PE%29&macrotema=demografia&_=1000&gerado_apos=2026-08-04T17%3A01%3A17.000Z",
+    );
+  });
 });

--- a/src/features/reports/automaticReport.ts
+++ b/src/features/reports/automaticReport.ts
@@ -10,6 +10,7 @@ export type AutomaticReportMacrothemeSlug =
 export type AutomaticReportRequest = {
   city: string;
   macrotheme: string;
+  geradoApos?: string;
 };
 
 const AUTOMATIC_REPORT_SLUGS = new Set<AutomaticReportMacrothemeSlug>([
@@ -85,6 +86,11 @@ export function joinReportSlugs(
  *
  * Example: `buildReportProxyUrl({ city, macrotheme: "saude,demografia" })` =>
  * `/api/reports/generate?city=Recife%20(PE)&macrotema=saude%2Cdemografia&_=1721600000000`.
+ *
+ * When `request.geradoApos` is provided, an extra `gerado_apos` query param is
+ * included so the proxy can filter the report index to entries written at or
+ * after that instant — preventing a stale PDF from a previous run from being
+ * served while a new one is being generated.
  */
 export function buildReportProxyUrl(request: AutomaticReportRequest): string {
   const params = new URLSearchParams({
@@ -92,6 +98,9 @@ export function buildReportProxyUrl(request: AutomaticReportRequest): string {
     macrotema: request.macrotheme,
     _: Date.now().toString(),
   });
+  if (request.geradoApos) {
+    params.set("gerado_apos", request.geradoApos);
+  }
 
   return `/api/reports/generate?${params.toString()}`;
 }

--- a/src/features/reports/automaticReport.ts
+++ b/src/features/reports/automaticReport.ts
@@ -81,17 +81,6 @@ export function joinReportSlugs(
   return slugs.join(",");
 }
 
-/**
- * Builds the public Next proxy URL for a generated report PDF.
- *
- * Example: `buildReportProxyUrl({ city, macrotheme: "saude,demografia" })` =>
- * `/api/reports/generate?city=Recife%20(PE)&macrotema=saude%2Cdemografia&_=1721600000000`.
- *
- * When `request.geradoApos` is provided, an extra `gerado_apos` query param is
- * included so the proxy can filter the report index to entries written at or
- * after that instant — preventing a stale PDF from a previous run from being
- * served while a new one is being generated.
- */
 export function buildReportProxyUrl(request: AutomaticReportRequest): string {
   const params = new URLSearchParams({
     city: request.city,

--- a/src/features/reports/reportGateway.ts
+++ b/src/features/reports/reportGateway.ts
@@ -10,6 +10,7 @@ type AutomaticReportEntry = {
   cidade: string;
   macrotema: string;
   pdf_url: string;
+  last_modified_utc?: string;
 };
 
 export type AvailableAutomaticReport = {
@@ -39,13 +40,16 @@ export function buildAutomaticReportGenerationUrl(
 /** Looks for one ready report without polling. Example: `await findAvailableAutomaticReport(params)`. */
 export async function findAvailableAutomaticReport(
   params: URLSearchParams,
+  geradoApos: string | null = null,
 ): Promise<AvailableAutomaticReport | null> {
   const city = requireCity(params);
   const slugs = parseAutomaticReportSlug(params.get("macrotema"));
   const reports = await fetchReportIndex();
+  const minGeneratedAt = geradoApos ? Date.parse(geradoApos) : null;
   const report = reports.find(
     (entry) =>
       Boolean(entry.pdf_url) &&
+      wasGeneratedAfter(entry, minGeneratedAt) &&
       matchesReportCity(entry.cidade, city) &&
       entryMatchesAnyMacrotheme(entry.arquivo_pdf, slugs),
   );
@@ -55,6 +59,25 @@ export async function findAvailableAutomaticReport(
     fileName: report.arquivo_pdf,
     pdfUrl: new URL(report.pdf_url, getAutomaticReportApiBaseUrl()).toString(),
   };
+}
+
+/**
+ * Filters out reports whose `last_modified_utc` predates `minGeneratedAt`.
+ * When `minGeneratedAt` is null (no freshness requirement), any report matches.
+ * Entries missing `last_modified_utc` are treated as unknown-age and are only
+ * accepted when no freshness requirement is set, so a backend that forgets to
+ * send the field cannot serve a stale PDF while a new one is being generated.
+ */
+function wasGeneratedAfter(
+  entry: AutomaticReportEntry,
+  minGeneratedAt: number | null,
+): boolean {
+  if (minGeneratedAt === null) return true;
+  if (!entry.last_modified_utc) return false;
+  const entryTime = Date.parse(entry.last_modified_utc);
+  if (Number.isNaN(entryTime)) return false;
+
+  return entryTime >= minGeneratedAt;
 }
 
 /**

--- a/src/features/reports/reportGateway.ts
+++ b/src/features/reports/reportGateway.ts
@@ -61,13 +61,6 @@ export async function findAvailableAutomaticReport(
   };
 }
 
-/**
- * Filters out reports whose `last_modified_utc` predates `minGeneratedAt`.
- * When `minGeneratedAt` is null (no freshness requirement), any report matches.
- * Entries missing `last_modified_utc` are treated as unknown-age and are only
- * accepted when no freshness requirement is set, so a backend that forgets to
- * send the field cannot serve a stale PDF while a new one is being generated.
- */
 function wasGeneratedAfter(
   entry: AutomaticReportEntry,
   minGeneratedAt: number | null,


### PR DESCRIPTION
# Frontend PR: Filter automatic-report polling by generation timestamp

## Summary

Captures the instant a report generation is triggered and forwards it as a `gerado_apos` query parameter on every subsequent polling request. The matching logic in `reportGateway.ts` then ignores any entry in the `/relatorios` index whose `last_modified_utc` predates that instant, so the client cannot settle on a PDF produced by a previous run.

## Problem

Today, `ReportBuilder` clicks "Gerar relatório", triggers `POST /api/reports/generate`, and then polls `GET /api/reports/generate` every two seconds until the backend reports a match. The matching is purely structural: same city and same macrotheme slug in the PDF filename.

When the user regenerates a report for a `(city, macrotheme)` that has been generated before, the previous PDF is still on disk while the new one is being rendered. The polling matches that previous PDF almost immediately — sometimes before the new PDF even exists — and the UI displays the stale artifact.

## Solution

Introduce a freshness cursor that travels from the client, through the Next.js proxy, into the matching helper.

1. **`src/components/ReportBuilder/ReportBuilder.tsx`** — in `requestReportPreview`, capture `new Date().toISOString()` immediately before the `POST` and pass it through to `buildReportProxyUrl` so every URL emitted during the polling loop carries the same anchor.

2. **`src/features/reports/automaticReport.ts`** — `AutomaticReportRequest` gains an optional `geradoApos` field. `buildReportProxyUrl` appends `gerado_apos=<iso>` to the proxy URL when provided.

3. **`src/app/api/reports/generate/route.ts`** and **`src/app/api/reports/download/route.ts`** — the route handlers read `gerado_apos` from `request.nextUrl.searchParams` and forward it as the second argument to `findAvailableAutomaticReport`, so the proxy and the eventual PDF download agree on which artifact to serve.

4. **`src/features/reports/reportGateway.ts`** — `AutomaticReportEntry` gains an optional `last_modified_utc` field (the FastAPI `/relatorios` index already exposes it). `findAvailableAutomaticReport` now accepts `geradoApos: string | null = null` and parses it once outside the iteration to avoid re-parsing per entry. A small helper, `wasGeneratedAfter`, filters entries whose timestamp predates the cursor or is missing/invalid. The comparison is fail-closed: an entry without a usable `last_modified_utc` is rejected when a freshness requirement is set, so a backend that forgets to send the field cannot leak a stale PDF while a new one is in flight.

5. **Tests** — `automaticReport.test.ts` covers the new `gerado_apos` query param. `route.test.ts` mocks include `last_modified_utc` and gains two cases: one verifying that a `gerado_apos` newer than every indexed entry yields `202 processing`, and one verifying that a `gerado_apos` older than the entries yields `200 ready`.

## Why both `gerado_apos` filtering and backend-side invalidation

This PR is the frontend half of a defense-in-depth fix. The backend (sibling PR in `Automatic-Reporting`) removes the previous PDF and HTML from disk before the new background task runs, so the index is empty during the generation window. The frontend filter covers cases where that backend change is not yet deployed, or where the generation completes faster than the first poll: in those cases the stale PDF may still be indexed for one or two cycles, but the timestamp filter prevents the client from accepting it.

## Files changed

- `src/components/ReportBuilder/ReportBuilder.tsx` — capture `geradoApos` before the `POST`.
- `src/features/reports/automaticReport.ts` — add `geradoApos` to the request type and proxy URL builder.
- `src/features/reports/reportGateway.ts` — extend the entry type, accept the cursor, and filter with `wasGeneratedAfter`.
- `src/app/api/reports/generate/route.ts` — forward `gerado_apos` to the gateway.
- `src/app/api/reports/download/route.ts` — forward `gerado_apos` to the gateway so the download matches the polling result.
- `src/features/reports/automaticReport.test.ts` — cover the new query parameter.
- `src/app/api/reports/generate/route.test.ts` — cover stale and fresh cases, with `last_modified_utc` on mocked entries.

## Testing

- `npm test` — all report-related suites pass; the only remaining failure is a pre-existing test in `ExploreFilters.test.tsx` that fails on `main` without these changes.
- `npm run lint` — clean.
- `npx tsc --noEmit` — no new errors introduced; the remaining type errors are pre-existing in unrelated tests (`PreviewCard.test.tsx`, `PreviewContent.test.tsx`, `content.test.ts`, `useMergedExploreSearch.test.tsx`).

## Backward compatibility

`geradoApos` is optional everywhere it appears: the request type, the URL builder, and `findAvailableAutomaticReport` (`geradoApos: string | null = null`). Callers that do not pass the cursor — including the existing test fixtures — continue to work and accept any entry in the index.
