### PR TITLE
Feat/UI improvement

### DIFF
--- a/src/components/ReportBuilder/MunicipalitySearch.tsx
+++ b/src/components/ReportBuilder/MunicipalitySearch.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type { KeyboardEvent, ReactElement } from "react";
+import { useMemo, useRef, useState } from "react";
+import { Icon } from "@/components/Icon/Icon";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { filterMunicipalitySuggestions } from "@/features/reports/municipalitySearch";
+import { cn } from "@/lib/utils";
+
+type MunicipalitySearchProps = {
+  cities: string[];
+  onChange: (value: string) => void;
+  value: string;
+};
+
+export function MunicipalitySearch({
+  cities,
+  onChange,
+  value,
+}: MunicipalitySearchProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const suggestions = useMemo(
+    () => filterMunicipalitySuggestions(value, cities),
+    [value, cities],
+  );
+  const activeIndex = Math.min(highlightedIndex, suggestions.length - 1);
+  const showSuggestions = open && suggestions.length > 0;
+
+  const selectSuggestion = (city: string): void => {
+    onChange(city);
+    setOpen(false);
+    setHighlightedIndex(0);
+    inputRef.current?.focus();
+  };
+
+  const handleChange = (nextValue: string): void => {
+    onChange(nextValue);
+    setHighlightedIndex(0);
+    setOpen(true);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (suggestions.length === 0) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightedIndex((index) => (index + 1) % suggestions.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedIndex(
+        (index) => (index - 1 + suggestions.length) % suggestions.length,
+      );
+    } else if (event.key === "Enter") {
+      const city = suggestions[activeIndex];
+      if (city) {
+        event.preventDefault();
+        selectSuggestion(city);
+      }
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <Popover onOpenChange={setOpen} open={showSuggestions}>
+      <PopoverAnchor asChild>
+        <label className="mt-4 flex h-10 w-full items-center gap-2 rounded-lg bg-[#EFEFEF] px-3">
+          <span className="sr-only">Pesquise o município</span>
+          <input
+            ref={inputRef}
+            aria-autocomplete="list"
+            aria-activedescendant={
+              showSuggestions
+                ? `report-municipality-option-${activeIndex}`
+                : undefined
+            }
+            aria-controls="report-municipality-suggestions"
+            aria-expanded={showSuggestions}
+            className="min-w-0 flex-1 bg-transparent text-sm text-[#292929] outline-none placeholder:text-[#737373]"
+            onChange={(event) => handleChange(event.target.value)}
+            onFocus={() => setOpen(true)}
+            onKeyDown={handleKeyDown}
+            placeholder="Pesquise o município"
+            role="combobox"
+            type="search"
+            value={value}
+          />
+          <Icon id="search-icon" size={12} />
+        </label>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        className="border border-grey-400 bg-white p-0"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        sideOffset={4}
+      >
+        <ul
+          id="report-municipality-suggestions"
+          role="listbox"
+          className="max-h-64 overflow-auto py-1"
+        >
+          {suggestions.map((city, index) => (
+            <li key={city} className="list-none">
+              <button
+                aria-selected={index === activeIndex}
+                className={cn(
+                  "block w-full px-3 py-2 text-left text-sm text-[#292929]",
+                  index === activeIndex && "bg-[#DDEADF]",
+                )}
+                id={`report-municipality-option-${index}`}
+                onClick={() => selectSuggestion(city)}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                role="option"
+                type="button"
+              >
+                {city}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ReportBuilder/ReportBuilder.test.tsx
+++ b/src/components/ReportBuilder/ReportBuilder.test.tsx
@@ -15,7 +15,7 @@ describe("ReportBuilder", () => {
     vi.unstubAllGlobals();
   });
 
-  it("opens the theme step after a municipality is selected", async () => {
+  it("opens the theme step after a municipality is selected from suggestions", async () => {
     const citiesApi = new FakeCitiesApi();
     vi.stubGlobal("fetch", citiesApi.fetch);
     const user = userEvent.setup();
@@ -25,13 +25,12 @@ describe("ReportBuilder", () => {
     const municipalitySearch = screen.getByPlaceholderText(
       "Pesquise o município",
     );
-    await waitFor(() => {
-      expect(
-        document.querySelector('option[value="Campina Grande"]'),
-      ).toBeInTheDocument();
-    });
+    await user.type(municipalitySearch, "campina");
 
-    await user.type(municipalitySearch, "Campina Grande");
+    const suggestion = await screen.findByRole("option", {
+      name: "Campina Grande",
+    });
+    await user.click(suggestion);
 
     await waitFor(() =>
       expect(
@@ -41,5 +40,22 @@ describe("ReportBuilder", () => {
     expect(
       screen.getByRole("button", { name: /Selecione o município/ }),
     ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("suggests accented municipalities when typing without accents", async () => {
+    const citiesApi = new FakeCitiesApi();
+    vi.stubGlobal("fetch", citiesApi.fetch);
+    const user = userEvent.setup();
+
+    render(<ReportBuilder themes={[]} />);
+
+    const municipalitySearch = screen.getByPlaceholderText(
+      "Pesquise o município",
+    );
+    await user.type(municipalitySearch, "joao");
+
+    expect(
+      await screen.findByRole("option", { name: "João Pessoa" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/ReportBuilder/ReportBuilder.tsx
+++ b/src/components/ReportBuilder/ReportBuilder.tsx
@@ -425,6 +425,7 @@ function ReportThemeList({
             iconId={iconId}
             color={theme.color}
             name={theme.name}
+            href={`/macrothemes/${theme.id.replace(/_/g, "-")}`}
             checked={selectedThemeIds.includes(theme.id)}
             disabled={disabled}
             className="w-full"

--- a/src/components/ReportBuilder/ReportBuilder.tsx
+++ b/src/components/ReportBuilder/ReportBuilder.tsx
@@ -10,6 +10,7 @@ import {
   ReportPreview,
   type ReportPreviewDocument,
 } from "@/components/ReportBuilder/ReportPreview";
+import { MunicipalitySearch } from "@/components/ReportBuilder/MunicipalitySearch";
 import {
   ReportStep,
   ReportSteps,
@@ -26,6 +27,7 @@ import {
   joinReportSlugs,
   type AutomaticReportMacrothemeSlug,
 } from "@/features/reports/automaticReport";
+import { resolveMunicipality } from "@/features/reports/municipalitySearch";
 import type { ContentfulRichTextField, MacroTheme } from "@/utils/interfaces";
 import { normalizeKey, sortContentByDesiredOrder } from "@/utils/functions";
 
@@ -67,6 +69,11 @@ export function ReportBuilder({
     supportedThemeIds,
   );
 
+  // INTENTIONAL: Resolve the typed municipality against the known city list
+  // using accent- and case-insensitive normalization, so users can type
+  // "campina grande" or "sao luis" and still select "Campina Grande" / "São Luís".
+  const resolvedMunicipality = resolveMunicipality(municipality, cities);
+
   useEffect(() => {
     void loadReportCities(setCities, setLoadingCities, setErrorMessage);
   }, []);
@@ -87,7 +94,7 @@ export function ReportBuilder({
   };
 
   const generateReport = async (): Promise<void> => {
-    const request = buildReportRequest(municipality, selectedThemeIds);
+    const request = buildReportRequest(resolvedMunicipality, selectedThemeIds);
     if (!request) {
       setErrorMessage(
         "Selecione um município e ao menos um macrotema disponível.",
@@ -176,7 +183,8 @@ function ReportBuilderLayout({
   themeText?: ContentfulRichTextField;
 }): ReactElement {
   const [openStep, setOpenStep] = useState<ReportStepId | "">("municipality");
-  const municipalitySelected = cities.includes(municipality.trim());
+  const municipalitySelected =
+    resolveMunicipality(municipality, cities) !== null;
   const themesSelected = selectedThemeIds.length > 0;
   const formCompleted = municipalitySelected && themesSelected;
 
@@ -335,42 +343,6 @@ function MunicipalityField({
         </p>
       )}
     </>
-  );
-}
-
-function MunicipalitySearch({
-  cities,
-  onChange,
-  value,
-}: {
-  cities: string[];
-  onChange: (value: string) => void;
-  value: string;
-}): ReactElement {
-  return (
-    <label className="mt-4 flex h-10 w-full items-center gap-2 rounded-lg bg-[#EFEFEF] px-3">
-      <span className="sr-only">Pesquise o município</span>
-      <input
-        className="min-w-0 flex-1 bg-transparent text-sm text-[#292929] outline-none placeholder:text-[#737373]"
-        onChange={(event) => onChange(event.target.value)}
-        placeholder="Pesquise o município"
-        list="report-municipalities"
-        type="search"
-        value={value}
-      />
-      <MunicipalityOptions cities={cities} />
-      <Icon id="search-icon" size={12} />
-    </label>
-  );
-}
-
-function MunicipalityOptions({ cities }: { cities: string[] }): ReactElement {
-  return (
-    <datalist id="report-municipalities">
-      {cities.map((city) => (
-        <option key={city} value={city} />
-      ))}
-    </datalist>
   );
 }
 
@@ -547,13 +519,13 @@ function hasSelectedAllThemes(
 }
 
 function buildReportRequest(
-  city: string,
+  city: string | null,
   selectedThemeIds: string[],
 ): { city: string; macrotheme: string } | null {
   const macrotheme = resolveSelectedMacrotheme(selectedThemeIds);
-  if (!city.trim() || !macrotheme) return null;
+  if (!city || !macrotheme) return null;
 
-  return { city: city.trim(), macrotheme };
+  return { city, macrotheme };
 }
 
 function resolveSelectedMacrotheme(selectedThemeIds: string[]): string | null {

--- a/src/features/reports/municipalitySearch.test.ts
+++ b/src/features/reports/municipalitySearch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterMunicipalitySuggestions,
+  resolveMunicipality,
+} from "./municipalitySearch";
+
+const CITIES = ["Campina Grande", "João Pessoa", "São Luís", "Recife"];
+
+describe("resolveMunicipality", () => {
+  it("resolves a query written without accents to the canonical city name", () => {
+    expect(resolveMunicipality("sao luis", CITIES)).toBe("São Luís");
+  });
+
+  it("is case-insensitive and tolerant of extra whitespace", () => {
+    expect(resolveMunicipality("  JOÃO  PESSOA ", CITIES)).toBe("João Pessoa");
+  });
+
+  it("returns null for an empty query or a non-matching city", () => {
+    expect(resolveMunicipality("", CITIES)).toBeNull();
+    expect(resolveMunicipality("   ", CITIES)).toBeNull();
+    expect(resolveMunicipality("Fortaleza", CITIES)).toBeNull();
+  });
+});
+
+describe("filterMunicipalitySuggestions", () => {
+  it("matches by accent-insensitive prefix", () => {
+    expect(filterMunicipalitySuggestions("sao", CITIES)).toEqual(["São Luís"]);
+    expect(filterMunicipalitySuggestions("joao", CITIES)).toEqual([
+      "João Pessoa",
+    ]);
+  });
+
+  it("preserves the original cities order", () => {
+    const shuffled = ["São Luís", "Campina Grande", "Recife", "João Pessoa"];
+    expect(filterMunicipalitySuggestions("", shuffled)).toEqual(shuffled);
+    expect(filterMunicipalitySuggestions("sa", shuffled)).toEqual(["São Luís"]);
+  });
+
+  it("caps the empty-query list to a fixed suggestion count", () => {
+    const manyCities = Array.from(
+      { length: 30 },
+      (_, index) => `Cidade ${index}`,
+    );
+    const suggestions = filterMunicipalitySuggestions("", manyCities);
+
+    expect(suggestions).toHaveLength(8);
+  });
+});

--- a/src/features/reports/municipalitySearch.ts
+++ b/src/features/reports/municipalitySearch.ts
@@ -1,0 +1,30 @@
+import { normalizeSearchText } from "@/features/search/search";
+
+export const MAX_MUNICIPALITY_SUGGESTIONS = 8;
+
+export function resolveMunicipality(
+  query: string,
+  cities: string[],
+): string | null {
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery) return null;
+
+  return (
+    cities.find((city) => normalizeSearchText(city) === normalizedQuery) ?? null
+  );
+}
+
+export function filterMunicipalitySuggestions(
+  query: string,
+  cities: string[],
+): string[] {
+  const normalizedQuery = normalizeSearchText(query);
+  const matches = cities.filter(
+    (city) =>
+      !normalizedQuery || normalizeSearchText(city).startsWith(normalizedQuery),
+  );
+
+  return normalizedQuery
+    ? matches
+    : matches.slice(0, MAX_MUNICIPALITY_SUGGESTIONS);
+}


### PR DESCRIPTION
# Accent-insensitive municipality search + macrotheme link in the report form

## Summary

Improves the automatic report form (`/reports`):

1. **Accent-insensitive municipality search** — replaces the native `<datalist>` (which only matches literal text) with a custom autocomplete that ignores accents, case, and extra whitespace, and sends the canonical city name to the backend.
2. **Navigable macrotheme cards** — each theme card now has an "Acesse o tema" link to the `/macrothemes/{slug}` page.

## Problem

- The municipality popup used `<datalist>`, whose matching is controlled by the browser and is **not accent-insensitive**: typing `sao miguel` never matched "São Miguel".
- Form validation compared the typed text **exactly** against the city list (`cities.includes(...)`), so typing without accents was never accepted.
- Theme cards in the form rendered without `href`, missing the "Acesse o tema" affordance present in Explore Filters.

## Changes

### 1. Accent-insensitive municipality search

**New: `src/features/reports/municipalitySearch.ts`** — pure logic built on the existing `normalizeSearchText`:
- `resolveMunicipality(query, cities)` — resolves the typed text to the **canonical name** (e.g., `sao luis` → `São Luís`) or `null`.
- `filterMunicipalitySuggestions(query, cities)` — prefix-matched suggestions preserving the API order; the empty query is capped at 8 items (`MAX_MUNICIPALITY_SUGGESTIONS`).

**New: `src/components/ReportBuilder/MunicipalitySearch.tsx`** — custom autocomplete:
- Filters suggestions on each keystroke via `filterMunicipalitySuggestions`.
- Renders the listbox through a **Radix Popover portal** so it escapes the accordion step's `overflow-hidden` (the native dropdown was clipped and invisible).
- Clicking a suggestion sets the canonical name; keyboard support: `↑`/`↓` navigate, `Enter` selects, `Esc` closes.
- ARIA attributes (`combobox`, `listbox`, `option`, `aria-expanded`, `aria-activedescendant`).

**`src/components/ReportBuilder/ReportBuilder.tsx`**:
- Removed the inline `MunicipalitySearch`/`MunicipalityOptions` (`<datalist>`).
- `municipalitySelected` now uses `resolveMunicipality(...) !== null` instead of the strict `cities.includes(...)`.
- `generateReport` builds the request with the **resolved canonical city**, so the backend always receives the official name (e.g., "São Miguel") even when the user typed "sao miguel".
- `buildReportRequest` accepts `city: string | null`.

### 2. Macrotheme link on theme cards

**`src/components/ReportBuilder/ReportBuilder.tsx`** — `ReportThemeList` now passes `href={`/macrothemes/${theme.id.replace(/_/g, "-")}`}` to `ThemeFilterCard`, matching the pattern already used in `ExploreFilters.tsx`, so the card renders the "Acesse o tema" link + tooltip.

## Tests

- `src/components/ReportBuilder/ReportBuilder.test.tsx` — updated to exercise the custom suggestions popup; new case proving typing `joao` suggests "João Pessoa".
- `src/features/reports/municipalitySearch.test.ts` (new) — covers `resolveMunicipality` (accent/case/whitespace tolerance, null cases) and `filterMunicipalitySuggestions` (accent-insensitive prefix, preserved order, 8-item cap).

## Notes

- The native `<datalist>` cannot be customized to ignore accents; a custom listbox is the only way to meet the requirement. Suggestions keep the API-provided order to match the previous `<datalist>` behavior.
- The empty-query popup is capped at 8 suggestions to avoid rendering ~1,800 municipalities on focus; typing narrows the results.