### PR TITLE
fix: add next.js as proxy to contentful

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,14 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
+  async rewrites() {
+    return [
+      {
+        source: "/contentful-assets/:path*",
+        destination: "https://images.ctfassets.net/:path*",
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary (Closes #321 )

Fixes broken Contentful images in local development (`next dev`).

After #308, Contentful asset URLs are rewritten to the `/contentful-assets/`
path so the Nginx cache proxy can serve (and cache) them, and
`images.ctfassets.net` was removed from Next.js `remotePatterns`.

This works on beta, where Nginx answers `/contentful-assets/`. But local dev
machines have no Nginx, so every Contentful image request returned **404** and
the site rendered without images.

## Solution

Added a Next.js `rewrite` in `next.config.mjs` that maps
`/contentful-assets/:path*` to `https://images.ctfassets.net/:path*`.

The rewrite only applies when no Nginx proxy is in front of the app — so it is a
no-op on beta (Nginx intercepts the path first) and restores image loading in
`next dev`.

## Changes

- `next.config.mjs`: proxy `/contentful-assets/:path*` to
  `https://images.ctfassets.net/:path*` for local development.

