### PR TITLE
fix: pdf viewer

### DIFF
--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -429,5 +429,5 @@
 }
 .pdf-viewer-fullscreen .pdf-viewer-canvas-wrapper {
   max-height: none;
-  overflow: visible;
+  overflow: auto;
 }

--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -427,3 +427,7 @@
     justify-content: center;
   }
 }
+.pdf-viewer-fullscreen .pdf-viewer-canvas-wrapper {
+  max-height: none;
+  overflow: visible;
+}

--- a/src/components/PdfViewer/PdfViewer.tsx
+++ b/src/components/PdfViewer/PdfViewer.tsx
@@ -89,8 +89,11 @@ export const PdfViewer = ({ pdfUrl, fileName, emptyState }: PdfViewerProps) => {
 
     if (document.fullscreenElement) {
       document.exitFullscreen();
+      setZoom(INITIAL_ZOOM);
+      containerRef.current.classList.remove("pdf-viewer-fullscreen");
     } else {
       containerRef.current.requestFullscreen();
+      containerRef.current.classList.add("pdf-viewer-fullscreen");
     }
   };
 


### PR DESCRIPTION
## Fix: PDF Viewer Fullscreen Clipping
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e7eb8af2-9efb-479f-b2bb-e7b89e271f5d" />

**Problem**  
- The PDF viewer is limited by `max-height: 80vh` in the canvas wrapper, causing the document to be cut off when fullscreen is enabled.  
- Upon exiting fullscreen the zoom remains reduced, leaving the PDF stretched instead of returning to its original size.

**Solution**  
- Added a `.pdf-viewer-fullscreen` CSS class that removes the `max-height` restriction while fullscreen is active, allowing the canvas to expand to the full viewport.  
- Updated the `toggleFullscreen` handler to:  
  - Add the class when entering fullscreen.  
  - Remove the class and reset the zoom to `INITIAL_ZOOM` (100 %) when exiting, ensuring the document returns to its normal scale.  
- Modified `PdfViewer.css` to include the new rule for `.pdf-viewer-fullscreen .pdf-viewer-canvas-wrapper`.