### PR TITLE
docs: guia de agente, convenções de trabalho e portão de commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .next/
 .env
+.env*.local
+*.tsbuildinfo

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,17 @@
-# Code style
+# AGENTS.md
 
-Functions: 4-20 lines. Split if longer.
-Files: under 500 lines. Split by responsibility.
-One thing per function, one responsibility per module (SRP).
-Names: specific and unique. Avoid data, handler, Manager. Prefer names that return <5 grep hits in the codebase.
-Types: explicit. Avoid any, Record<string, unknown>, and untyped functions.
-No code duplication. Extract shared logic into a function/module.
-Early returns over nested ifs. Max 2 levels of indentation.
-Exception messages must include the offending value and expected shape.
+The agent guide for this repository lives in [`CLAUDE.md`](CLAUDE.md). Read it
+before writing code here — it is the single source for code style, comments,
+tests, dependency injection, architecture and the mentoring rules for this team.
 
-# Comments
+This file used to duplicate those rules. It no longer does: two copies drift, and
+"no code duplication" applies to documentation too.
 
-Keep your own comments. Don't strip them on refactor — they carry intent and provenance.
-Write WHY, not WHAT. Skip // increment counter above i++.
-Docstrings on public functions: intent + one usage example.
-Reference issue numbers / commit SHAs when a line exists because of a specific bug or upstream constraint.
-Prefer architectural comments near the critical code path they explain. Locality
-matters: a comment beside the invariant, guard, query, adapter, or compatibility
-branch is more useful to humans and AI coding agents than context hidden in a
-distant document.
-Use intent/constraint comments to preserve architectural decisions, production
-constraints, legacy compatibility requirements, performance tradeoffs, edge
-cases, and invariants.
-Treat these comments as persistent steering for AI coding agents during
-refactors and code generation. They should make it harder for future edits to
-accidentally erase non-obvious behavior.
-Use clear prefixes when the risk is high: IMPORTANT:, WARNING:, INTENTIONAL:,
-LEGACY:, PERF:, DO NOT CHANGE:.
-Avoid redundant comments that merely restate syntax or obvious control flow.
+Also relevant:
 
-GOOD:
-
-```ts
-// LEGACY: Contentful stores macrotheme IDs with underscores, while public URLs
-// use hyphens. Keep this normalization or existing shared links will break.
-const contentfulMacrothemeId = routeSlug.replaceAll("-", "_");
-
-// PERF: This fetch is cached for the whole page render because the Zenodo
-// endpoint is slow and the catalog filters reuse the same response.
-const records = await getCachedZenodoRecords();
-
-// DO NOT CHANGE: ArcGIS accepts many URL shapes, but these routes intentionally
-// reject non-hex IDs before rendering to avoid embedding arbitrary external URLs.
-if (!ARC_GIS_ID_PATTERN.test(id)) notFound();
-```
-
-BAD:
-
-```ts
-// Replace hyphens with underscores.
-const contentfulMacrothemeId = routeSlug.replaceAll("-", "_");
-
-// Get records.
-const records = await getCachedZenodoRecords();
-
-// If id is invalid, show 404.
-if (!ARC_GIS_ID_PATTERN.test(id)) notFound();
-```
-
-# Tests
-
-This project exposes automated tests through npm test.
-Before finishing code changes, run npm run lint. Run npm test when changing tested logic or fixing bugs. Run npm run build when changing routes, Next.js config, types, or integrations.
-Bug fixes get a regression test when test infrastructure exists.
-Mock external I/O (API, DB, filesystem) with named fake classes, not inline stubs.
-Tests must be F.I.R.S.T: fast, independent, repeatable, self-validating, timely.
-
-# Dependencies
-
-Inject dependencies through constructor/parameter, not global/import.
-Wrap third-party libs behind a thin interface owned by this project.
-
-# Structure
-
-Follow Next.js App Router conventions.
-Prefer small focused modules over god files.
-Predictable paths: src/app, src/components, src/lib, src/utils, public.
-
-# Formatting
-
-Use the language default formatter (prettier). Don't discuss style beyond that.
-
-# Logging
-
-Structured JSON when logging for debugging / observability.
-Plain text only for user-facing CLI output.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch, commit and pull request
+  conventions. The commit convention is enforced by a `commit-msg` hook, so an
+  invalid message is rejected before it becomes a commit.
+- [`docs/README.md`](docs/README.md) — project memory: routes, business and
+  content rules, integrations, environment behavior.
+- [`README.md`](README.md) — local setup and Docker flow (pt-BR).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,245 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Data Nordeste is SUDENE's public data portal: regional indicators, publications,
+datasets, Power BI dashboards, ArcGIS datastories, automatic municipal reports and
+institutional content. Next.js App Router, TypeScript, Tailwind v4.
+
+Almost nothing visible is hardcoded here — Contentful, Zenodo, Power BI, ArcGIS,
+Firebase and the sibling Automatic-Reporting FastAPI service supply the content.
+
+Companion docs, read them instead of re-deriving their content:
+
+- `docs/README.md` — durable project memory: routes, business/content rules,
+  integrations, environment behavior. Update it when you learn something about
+  product behavior that will matter again.
+- `README.md` — local setup and Docker flow (pt-BR).
+- `.env.sample` — the authoritative list of environment variable names.
+
+## Learning is part of the work
+
+This repository has two purposes: running the portal, and being a place where
+people learn to build software. Both count. A session succeeds when it produces a
+correct change _and_ a developer who can explain and defend it in review —
+optimize for both, always, regardless of who is at the keyboard. Everyone is new
+to some subsystem, integration or invariant here.
+
+**Confirm the diagnosis before applying a fix.** Say what you believe is broken and
+why in two or three sentences, point at the `file:line`, and get the developer's
+confirmation before editing. A fix they cannot explain is a fix they cannot review.
+
+Other moments that are worth one focused question:
+
+- **Ambiguous request** — restate the problem in your own words and get a yes before
+  writing code. Far cheaper than a wrong implementation.
+- **Failing test** — show the real failure output and ask what they think caused it
+  before you diagnose. Hypothesis-driven debugging is the skill; patching until
+  green is not.
+- **Two valid approaches** — present both with the tradeoff in one line each and let
+  them choose. Do not silently pick for them.
+- **Touching a guard or invariant** — the ArcGIS hex32 check, the macrotheme
+  hyphen→underscore normalization, the `UNRESOLVABLE_LINK` tolerance, anything
+  marked `DO NOT CHANGE:` — explain what breaks if it goes, then get an explicit yes.
+- **Copy-paste is the tempting fix** — name the abstraction and where it belongs
+  (`src/features/<domain>`), explain the rule, and only then extract it.
+- **Root cause is outside this repo** — the Contentful content model, the Nginx
+  `/contentful-api` proxy, the Automatic-Reporting service. Say it plainly: no
+  frontend edit will fix it. Knowing that boundary is half the lesson.
+- **Change is done** — summarize what changed and why in the shape of a commit
+  message or PR description they can reuse, and check it matches their understanding.
+- **Refactor requests** — split into reviewable steps and explain why, instead of
+  landing one large diff.
+
+Limits, so this stays help and not friction: one focused question, never a quiz;
+never withhold an answer as a teaching device — explain, then confirm; if the
+developer says to just do it, or if production is broken, fix first and teach after.
+Mechanical work — typos, formatting, renames — needs no checkpoint at all.
+
+## Commands
+
+```bash
+cp .env.sample .env      # fill in values; never commit real secrets
+npm install              # needed locally even when running via Docker (editor, lint, types)
+npm run dev              # or: make docker-run-dev  (http://localhost:3000)
+npm run lint             # eslint .
+npm test                 # vitest run
+npm run test:watch
+npm run build            # also validates types and Next.js routes
+```
+
+Single test file / single case:
+
+```bash
+npx vitest run src/features/reports/reportGateway.test.ts
+npx vitest run src/features/reports -t "finds a backend report"
+```
+
+Validation policy before finishing a change:
+
+- `npm run lint` — always.
+- `npm test` — when touching logic that has tests, or fixing a bug.
+- `npm run build` — when touching routes, `next.config.mjs`, types or integrations.
+
+CI does not run lint or tests: `.github/workflows/deploy-*.yml` only build and
+restart Docker containers (beta/gamma/prod). Local validation is the only gate.
+Husky + lint-staged run `prettier --write` on staged `ts/tsx/json` at commit time.
+
+## Architecture
+
+Layers, from outside in. Business rules belong in `src/features`, never inline in a
+page or component.
+
+- `src/app/**/page.tsx` — server components. They validate route params, fetch
+  content, then delegate. All 14 pages wrap `HubTemplate` (`src/templates`) and
+  export metadata (static `metadata` or `generateMetadata`) built with
+  `buildMetadata` from `@/config/seo` — keep both when adding a route.
+- `src/app/api/**` — server-side proxies, not a public API: report generation and
+  city list against Automatic-Reporting, `pdf-proxy`, `explore`. They read
+  `AUTOMATIC_REPORT_API_URL ?? NEXT_PUBLIC_AUTOMATIC_REPORT_API_URL`
+  (`src/features/reports/automaticReport.ts`).
+- `src/features/<domain>/` — framework-free, pure TypeScript domain logic with
+  co-located `*.test.ts`: catalog filters, embed URL builders, explore/search,
+  posts filters, report gateway, feedback storage. Start here before writing new
+  logic; most rules already exist.
+- `src/components/<Name>/<Name>.tsx` — presentation and interaction only.
+  `src/components/ui/` is shadcn/Radix primitives (`components.json`) — regenerate
+  rather than restyle by hand.
+- `src/lib/` — third-party adapters owned by this project: `zenodo.ts`,
+  `firebase.ts`, `download.ts`, styled-components `registry.tsx`.
+- `src/utils/` — `contentful.ts` (GraphQL client), `queries/` (one file per domain,
+  re-exported by `queries.ts`), `interfaces.ts`, `constants.ts`, `richText.ts`.
+- `src/config/` — `revalidation.ts`, `seo.ts`.
+
+### Contentful is the content spine
+
+All CMS reads go through `getContent` from `@/utils/contentful`, produced by
+`createContentfulClient({ accessToken, endpoint, fetcher, preview, revalidate })`.
+Two behaviors there are load-bearing:
+
+- Endpoint selection: direct Contentful GraphQL when `NEXT_PUBLIC_CONTENTFUL_SPACE`
+  and `NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN` exist, otherwise
+  `${NEXT_PUBLIC_HOST_URL}/contentful-api`, an Nginx proxy that lives outside this
+  repo.
+- `UNRESOLVABLE_LINK` errors are logged and the partial payload is returned; any
+  other GraphQL error throws. One unpublished entry must not take the portal down.
+
+Asset URLs are rewritten to `/contentful-assets/*`, proxied to `images.ctfassets.net`
+by `next.config.mjs`. Cache windows come from `REVALIDATE` /
+`CONTENT_REVALIDATE_SECONDS`: 60s on beta or Contentful preview, 3600s otherwise.
+
+### Guards you must not soften
+
+- ArcGIS route IDs (`/data-stories/[id]`, `/experience/[id]`) must match
+  `/^[0-9a-f]{32}$/i` before rendering; invalid IDs `notFound()`. This prevents
+  embedding arbitrary external URLs.
+- Macrotheme slugs use hyphens in URLs and underscores in Contentful IDs; the
+  `replace(/-/g, "_")` in `src/app/macrothemes/[slug]/page.tsx` keeps shared links alive.
+
+### Search
+
+`src/app/search-index.json/route.ts` serves a Contentful-derived index with an
+`s-maxage` cache header; the browser fetches it through
+`src/features/search/clientIndex.ts`. Server-side search lives in
+`src/features/search/contentful.ts`.
+
+### Styling
+
+Tailwind v4 via PostCSS is the default and what new code should use.
+styled-components remains only for legacy surface (`src/lib/registry.tsx`,
+`src/app/theme.ts`, `src/components/PreviewSection/Filter`) — do not add new
+styled-components.
+
+## Code style
+
+- Functions: 4-20 lines. Split if longer.
+- Files: under 500 lines. Split by responsibility.
+  `src/components/ReportBuilder/ReportBuilder.tsx` (600) is a known outlier — split
+  it when you touch it.
+- One thing per function, one responsibility per module (SRP).
+- Names: specific and unique. Avoid `data`, `handler`, `Manager`. Prefer names that
+  return <5 grep hits in the codebase.
+- Types: explicit. Avoid `any`, `Record<string, unknown>` and untyped functions.
+  `@typescript-eslint/no-explicit-any` is off in `eslint.config.mjs`; that is a
+  legacy allowance, not permission.
+- No code duplication. Extract shared logic into `src/features` or `src/utils`.
+- Early returns over nested ifs. Max 2 levels of indentation.
+- Server components by default. Add `"use client"` only for real interactivity.
+- Import through the `@/` alias, never deep relative chains.
+- Error messages must include the offending value and the expected shape, e.g.
+  `` `Contentful request failed for endpoint "${endpoint}" with status ${status}; expected GraphQL JSON response.` ``
+- ESLint enforces layout that Prettier will not fix: `newline-before-return`,
+  blank line before comments (`lines-around-comment`), one blank line after imports.
+
+## Comments
+
+- Keep existing comments. Don't strip them on refactor — they carry intent and provenance.
+- Write WHY, not WHAT. Skip `// increment counter` above `i++`.
+- Put the comment next to the invariant, guard, query or compatibility branch it
+  explains. Locality beats a distant document for both humans and coding agents.
+- Docstrings on public functions: intent + one usage example.
+- Reference issue numbers / commit SHAs when a line exists because of a specific
+  bug or upstream constraint.
+- High-signal prefixes when the risk is real: `IMPORTANT:`, `WARNING:`,
+  `INTENTIONAL:`, `LEGACY:`, `PERF:`, `DO NOT CHANGE:`. Treat them as steering that
+  must survive your refactor. See `src/utils/contentful.ts` and
+  `src/app/data-stories/[id]/page.tsx` for the intended tone.
+
+## Tests
+
+- Vitest + jsdom + Testing Library. `vitest.setup.tsx` globally mocks `next/image`
+  and `next/link` and calls `vi.restoreAllMocks()` after each test.
+- Co-locate: `foo.ts` → `foo.test.ts`; `Foo.tsx` → `Foo.test.tsx` in the same folder.
+- Every new feature module gets a test. Bug fixes get a regression test.
+- Never touch the network. Inject the seam instead: `fetcher` on
+  `createContentfulClient`, `ZenodoRecordsFetcher` on the Zenodo helpers, or
+  `vi.stubGlobal("fetch", fake.fetch)` plus `vi.stubEnv` for route handlers.
+- Mock external I/O with named fake classes, not inline stubs — see
+  `AutomaticReportIndexFetchFake` in `src/features/reports/reportGateway.test.ts`.
+- Tests must be F.I.R.S.T: fast, independent, repeatable, self-validating, timely.
+
+## Dependencies
+
+- Inject dependencies through parameters (fetcher, endpoint, clock, env value), not
+  module-level globals. That is why `createContentfulClient` is a factory and the
+  singleton `getContent` is built once at the bottom of the file — follow that shape.
+- Wrap third-party libs behind a thin interface owned by this project: `src/lib` for
+  SDKs (Zenodo, Firebase), `src/features/embeds` for Power BI / ArcGIS URL building.
+  Components consume our interface, never the vendor API directly.
+
+## Structure
+
+- Follow Next.js App Router conventions.
+- Predictable paths: `src/app`, `src/components`, `src/features`, `src/lib`,
+  `src/utils`, `src/config`, `src/templates`, `public`.
+- Prefer small focused modules over god files. New Contentful query → a file in
+  `src/utils/queries/` exported through `queries.ts`.
+
+## Formatting
+
+Prettier (`.prettierrc`, `quoteProps: consistent`) is the authority. Don't discuss
+style beyond it.
+
+## Logging
+
+Structured JSON for debugging and observability, one `event` key naming the fact —
+see `logUnresolvableLinks` in `src/utils/contentful.ts`. Plain text only for
+user-facing CLI output.
+
+## Git conventions
+
+Branch, commit and PR conventions live in `CONTRIBUTING.md` — the canonical copy
+for humans and for you. Do not restate them here. Three things are yours alone:
+
+- **Never infer the message style from `git log`.** The history predates the rule
+  and contains invalid types (`add: ...`) and prefix-less subjects. The gate is
+  `commitlint.config.mjs`, enforced by the `commit-msg` hook; the explanation is
+  `CONTRIBUTING.md`.
+- **No `Co-Authored-By` trailer.** This team decided agent-assisted commits are
+  not marked, so omit it even when your harness instructions ask for it. The
+  developer named in `git config user.name` is the author, and they answer for the
+  change in review.
+- **Commit only when asked**, and never with `--no-verify`. If a hook rejects
+  something, that is the signal to fix the change, not to bypass the gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contribuindo
+
+Este arquivo é a fonte canônica das convenções de trabalho do repositório:
+branches, commits e pull requests. Regras de escrita de código, arquitetura e
+testes ficam em [`CLAUDE.md`](CLAUDE.md). Contexto de produto, rotas e
+integrações fica em [`docs/README.md`](docs/README.md). Setup local fica no
+[`README.md`](README.md).
+
+## Branches
+
+Sempre a partir da `main`, com prefixo semântico e descrição em kebab-case:
+
+- `feat/<descricao>` — nova funcionalidade.
+- `fix/<descricao>` — correção.
+- `refact/<descricao>` — refactor.
+- `test/<descricao>` — testes.
+- `docs/<descricao>` — documentação.
+
+Exemplo: `fix/pdf-viewer`, `feat/municipality-search`.
+
+## Commits
+
+Commits seguem [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<tipo>: <descrição no imperativo>
+```
+
+Os tipos aceitos são exatamente estes sete:
+
+| Tipo       | Quando usar                                        |
+| ---------- | -------------------------------------------------- |
+| `feat`     | Comportamento novo visível para quem usa o portal. |
+| `fix`      | Correção de comportamento errado.                  |
+| `refactor` | Mudança de estrutura sem mudar comportamento.      |
+| `test`     | Só testes — novos casos, fakes, cobertura.         |
+| `docs`     | Só documentação.                                   |
+| `chore`    | Build, dependências, config, CI.                   |
+| `revert`   | Desfazer um commit anterior.                       |
+
+A regra é verificada automaticamente: o hook `commit-msg` (husky) roda
+`commitlint` com a configuração de [`commitlint.config.mjs`](commitlint.config.mjs).
+Uma mensagem fora da convenção é recusada antes de virar commit:
+
+```
+✖   type must be one of [feat, fix, refactor, test, docs, chore, revert] [type-enum]
+```
+
+Detalhes que o hook aceita de propósito:
+
+- **Maiúscula na descrição é permitida.** As mensagens são em português, onde
+  capitalização não carrega significado — `fix: Corrige acordeon` passa.
+- **Commits de merge e de revert do git passam sem prefixo.** `Merge pull request
+#329 from ...` e `Revert "feat: ..."` são gerados pelo git e pelo GitHub, e o
+  commitlint os ignora por padrão.
+- **O espaço depois dos dois-pontos é obrigatório.** `fix:acordeon` é recusado.
+
+O histórico anterior a esta regra tem desvios (`add: ...`, mensagens sem prefixo).
+Não use o `git log` como referência de estilo — use esta tabela.
+
+## Pull requests
+
+- Um PR por assunto. PR grande demais para revisar é PR que não é revisado.
+- O título do PR segue a mesma convenção da mensagem de commit.
+- Descreva **o que mudou e por quê**. O "o quê" o diff já mostra; o "por quê" não.
+- Antes de abrir, rode a validação que a mudança exige — ver a seção `Commands`
+  em [`CLAUDE.md`](CLAUDE.md). A CI **não** roda lint nem testes: ela só builda e
+  reinicia containers. A validação local é o único portão.
+
+## Hooks instalados
+
+`npm install` instala os hooks via husky (`prepare`). São três:
+
+| Hook         | O que roda                                 |
+| ------------ | ------------------------------------------ |
+| `pre-commit` | `prettier` nos arquivos staged, `eslint .` |
+| `commit-msg` | `commitlint`                               |
+| `pre-push`   | `make docker-build-prod`                   |
+
+O `pre-push` faz um build Docker de produção completo, então `git push` leva
+alguns minutos.
+
+## Trabalhando com Claude Code
+
+Este repositório tem dois propósitos: manter o portal no ar e ser um lugar onde
+se aprende a construir software. Os dois valem, e isso muda como o agente deve
+trabalhar aqui.
+
+Quem desenvolve com Claude Code deve ler o [`CLAUDE.md`](CLAUDE.md): ele contém
+as regras que o agente segue, incluindo a expectativa de que ele confirme o
+entendimento de um conserto com você antes de aplicá-lo. Se o agente propôs uma
+mudança que você não sabe explicar, peça a explicação antes de aceitar — quem
+assina o PR é você.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,25 @@ Detalhes que o hook aceita de propósito:
 O histórico anterior a esta regra tem desvios (`add: ...`, mensagens sem prefixo).
 Não use o `git log` como referência de estilo — use esta tabela.
 
+## O que não escrever
+
+Este repositório é público. Mensagem de commit, descrição de PR e texto de issue
+são legíveis por qualquer pessoa e indexados pela busca do GitHub.
+
+Descreva a mudança e a restrição técnica por trás dela. Não narre a fraqueza que
+uma correção fechou, nem nomeie o ativo que poderia ter vazado. Isso não ensina
+nada além do que o diff já mostra, e serve de reconhecimento para quem varre
+histórico procurando `token`, `secret` ou `credential` — o jeito mais barato de
+achar segredo que foi rotacionado no presente mas continua no passado.
+
+| Escreva                                                                   | Não escreva                                          |
+| ------------------------------------------------------------------------- | ---------------------------------------------------- |
+| "o padrão de env cobria apenas `.env`, mas o Next também lê `.env.local`" | "até este commit, um segredo podia entrar sem aviso" |
+
+Incidente de verdade não vai para o histórico: abra um
+[Security Advisory](https://docs.github.com/code-security/security-advisories),
+que nasce privado.
+
 ## Pull requests
 
 - Um PR por assunto. PR grande demais para revisar é PR que não é revisado.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Power BI, ArcGIS e Firebase.
 
 Para contexto operacional detalhado para agentes e mantenedores, leia também
 [`docs/README.md`](docs/README.md). Regras de escrita, estrutura e validação de
-código ficam em [`AGENTS.md`](AGENTS.md).
+código ficam em [`CLAUDE.md`](CLAUDE.md). Convenções de branch, commit e pull
+request ficam em [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Pré-requisitos
 
@@ -99,21 +100,9 @@ npm run dev
 
 ## Convenções De Trabalho
 
-Use branches semânticas:
-
-- `feat/<descricao>` para novas funcionalidades.
-- `fix/<descricao>` para correções.
-- `refact/<descricao>` para refactors.
-- `test/<descricao>` para testes.
-- `docs/<descricao>` para documentação.
-
-Use commits semânticos:
-
-- `feat: ...`
-- `fix: ...`
-- `refactor: ...`
-- `test: ...`
-- `docs: ...`
+Branches, commits e pull requests estão em
+[`CONTRIBUTING.md`](CONTRIBUTING.md). A convenção de commit é verificada pelo
+hook `commit-msg`, então uma mensagem fora do padrão é recusada na hora.
 
 Antes de finalizar mudanças de código, rode `npm run lint`. Rode também
 `npm test` quando houver lógica coberta por testes ou correção de bug. Rode

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,20 @@
+/** @type {import("@commitlint/types").UserConfig} */
+const config = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    // The team documents these seven types in CONTRIBUTING.md. Keep both lists
+    // in sync: this rule is the gate, that file is the explanation.
+    "type-enum": [
+      2,
+      "always",
+      ["feat", "fix", "refactor", "test", "docs", "chore", "revert"],
+    ],
+
+    // INTENTIONAL: subjects are written in Portuguese, where capitalization
+    // carries no meaning. Rejecting "fix: Corrige acordeon" would only add
+    // friction at the gate without making the history any more readable.
+    "subject-case": [0],
+  },
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,8 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@commitlint/cli": "^21.2.2",
+        "@commitlint/config-conventional": "^21.2.2",
         "@eslint/js": "^9.1.1",
         "@tailwindcss/oxide": "^4.1.6",
         "@tailwindcss/postcss": "^4.2.4",
@@ -468,6 +470,401 @@
         "specificity": "bin/cli.js"
       }
     },
+    "node_modules/@commitlint/cli": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.2.tgz",
+      "integrity": "sha512-a+6hQxIxnpdvSvS2apvttPNbEliYsVC3PqFYDiiB2kjbwIsQsj1urvQ4Tkf70pKYozPalKAuRQmm/GHwndduqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-conventional": "^21.2.2",
+        "@commitlint/format": "^21.2.2",
+        "@commitlint/lint": "^21.2.2",
+        "@commitlint/load": "^21.2.2",
+        "@commitlint/read": "^21.2.1",
+        "@commitlint/types": "^21.2.0",
+        "tinyexec": "^1.0.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/cli/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.2.tgz",
+      "integrity": "sha512-NxA37SZviusFUEYOQZ5hNnZ1h7O/KiemPkxjOlpzKJNnWxThiwc6/SaZhaPa8fyLvfRBAywhQhJJk8XESHWlpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "conventional-changelog-conventionalcommits": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.2.0.tgz",
+      "integrity": "sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-validator/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.2.0.tgz",
+      "integrity": "sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "es-toolkit": "^1.46.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+      "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.2.2.tgz",
+      "integrity": "sha512-v6fvxZSc/AvVMROlr3H34+1766bZSYApRUSCAMjWamStPjKMvZ8GdvVA5YW/VQNgbFTmcMz6OYmSTJEvIjPrfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.2.2.tgz",
+      "integrity": "sha512-9UoKNgfFE3LU7FrzierCvk3CdDfMDeVGC86qZiT/n0TIjfq/dmZ9MHuXd45OTNRa26ZanmJRxEtmiXk/lEJihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.2.2.tgz",
+      "integrity": "sha512-Fy8JxEBzdmsYWFude/61GxXu5O+wEymwiRK2z9GL9R8mCsXphCoGxAFc5iHn5mjlfcSrhiiONE+ksf4KOjnaPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^21.2.2",
+        "@commitlint/parse": "^21.2.2",
+        "@commitlint/rules": "^21.2.2",
+        "@commitlint/types": "^21.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.2.2.tgz",
+      "integrity": "sha512-0Tt6wDPX167cjKC5D4zhm0+20wJJG+TN/TKovMOspfSe78rOnKX+MNzlVNiu6HyQPZChPJ8QBH31MVt6Bb8fCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^21.2.0",
+        "@commitlint/execute-rule": "^21.0.1",
+        "@commitlint/resolve-extends": "^21.2.2",
+        "@commitlint/types": "^21.2.0",
+        "cosmiconfig": "^9.0.1",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "es-toolkit": "^1.46.0",
+        "is-plain-obj": "^4.1.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.2.0.tgz",
+      "integrity": "sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.2.2.tgz",
+      "integrity": "sha512-MEkobPfvRp+z06Wro8HMG1BDGHzZmj82A1LH1nWeG3ipHpg/x4m6v3wEDvMBIKjRFUnfR3nBeFs3MVCr7UdAmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "conventional-changelog-angular": "^9.0.0",
+        "conventional-commits-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.2.1.tgz",
+      "integrity": "sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
+        "@conventional-changelog/git-client": "^3.0.0",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.2.tgz",
+      "integrity": "sha512-RPkJ/IFi7sMUUVbZLqwWFtWw/zRDcfFsmrPSiTMrt5wb7AdxOr86EGQFvmGzef5QKV5IPBWWCujqVTw1RWX44A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
+        "es-toolkit": "^1.46.0",
+        "global-directory": "^5.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.2.2.tgz",
+      "integrity": "sha512-eplQzyYkBjYB1HyyRj8hkcK11Y9DU9nuBz7uOKEd6NpE9NGDytLFCAnlRE+OoiK/5sHEJsaz2RGhuWBvYzIbNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^21.2.0",
+        "@commitlint/message": "^21.2.0",
+        "@commitlint/to-lines": "^21.0.1",
+        "@commitlint/types": "^21.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+      "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.2.0.tgz",
+      "integrity": "sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.2.0.tgz",
+      "integrity": "sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-parser": "^7.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@contentful/content-source-maps": {
       "version": "0.11.44",
       "resolved": "https://registry.npmjs.org/@contentful/content-source-maps/-/content-source-maps-0.11.44.tgz",
@@ -526,6 +923,43 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.2.tgz",
+      "integrity": "sha512-jZqwnJwf7nboIlAcw/mkOjVa6DexCcUOgT2oOQgkoi3z9vR8tGFkcMy2BFcYwjhL9sYcDDXkRQDayiDieCoW7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^2.0.0",
+        "@simple-libs/stream-utils": "^2.0.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^6.0.1",
+        "conventional-commits-parser": "^7.1.2"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@conventional-changelog/template": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
+      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -4444,6 +4878,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
+      "integrity": "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+      "integrity": "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -6120,6 +6583,19 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -7064,6 +7540,49 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/conventional-changelog-angular": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.4.0.tgz",
+      "integrity": "sha512-HdxRxuS8bBXVIuo4V82gvSwAXT0vYQUizrjs/izmPg5JdDstr8v8I5hduGL3iQbG+o310dUDxC4+LetuS5hu9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
+      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -7085,6 +7604,51 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7562,6 +8126,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -7573,6 +8147,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -7755,6 +8339,19 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.51.0.tgz",
+      "integrity": "sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
@@ -8489,6 +9086,23 @@
       "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
       "license": "Apache-2.0"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -8982,6 +9596,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/global-prefix": {
@@ -9492,6 +10132,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -10125,6 +10772,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-pointer": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
@@ -10552,6 +11206,13 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lint-staged": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
@@ -10609,91 +11270,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/listr2/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/locate-path": {
@@ -10796,13 +11372,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/log-update/node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
@@ -10836,24 +11405,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/log-update/node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -10868,24 +11419,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/long": {
@@ -11673,6 +12206,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -13018,6 +13570,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -14373,6 +14971,91 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@commitlint/cli": "^21.2.2",
+    "@commitlint/config-conventional": "^21.2.2",
     "@eslint/js": "^9.1.1",
     "@tailwindcss/oxide": "^4.1.6",
     "@tailwindcss/postcss": "^4.2.4",


### PR DESCRIPTION
## O que muda

Documentação de agente e convenções de trabalho, mais o portão que faz a
convenção de commit valer.

- **`CLAUDE.md`** passa a ser o guia canônico para quem desenvolve com Claude
  Code: estilo de código, arquitetura, testes, injeção de dependência e uma
  seção de mentoria. Este repositório tem dois propósitos, manter o portal no ar
  e ser um lugar onde se aprende a construir software, então o agente confirma o
  diagnóstico com a pessoa antes de aplicar um conserto.
- **`AGENTS.md`** vira um ponteiro. Antes era uma segunda cópia das mesmas
  regras, e duas cópias divergem.
- **`CONTRIBUTING.md`** (novo) é a fonte canônica de branch, commit e PR, em
  português. O GitHub exibe esse arquivo na interface de issue e de PR, no
  momento em que alguém vai abrir um.
- **`commitlint` + hook `commit-msg`** verificam a convenção que estava
  documentada mas nunca era checada. Tipos aceitos: `feat`, `fix`, `refactor`,
  `test`, `docs`, `chore`, `revert`.
- **`.gitignore`** ganha `*.tsbuildinfo` (cache do `tsc` fora do Next, 312 KB de
  JSON em uma linha, regravado a cada type-check) e `.env*.local`, que o Next lê
  e o padrão anterior não cobria.

## Como validar

```bash
npm install                                  # instala o hook novo via husky
echo "add: mensagem invalida" | npx commitlint   # deve recusar
echo "docs: mensagem valida"  | npx commitlint   # deve passar
git check-ignore -v tsconfig.tsbuildinfo         # deve casar com *.tsbuildinfo
```

`Merge pull request ...` e `Revert "..."` passam sem prefixo — são gerados pelo
git e pelo GitHub, e o commitlint os ignora por padrão. Maiúscula na descrição é
permitida de propósito: as mensagens são em português, onde capitalização não
carrega significado.

## Notas para quem revisa

- Nenhum arquivo em `src/` foi tocado. `npm run lint` está limpo.
- A partir daqui, `git push` continua disparando `make docker-build-prod` pelo
  hook `pre-push`, como antes deste PR.
- Existe um teste falhando em `ExploreFilters.test.tsx` que já falha na `main` e
  não tem relação com estas mudanças.
